### PR TITLE
Rtabmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code
+.claude/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/config/rtsm.yaml
+++ b/config/rtsm.yaml
@@ -14,6 +14,35 @@ camera:
   cy: 259.239777
 
 # -------------------- Models --------------------
+# Segmentation backend: fastsam (open-world) or yoloworld (task-focused)
+segmentation:
+  backend: fastsam                    # fastsam | yoloworld
+
+  fastsam:
+    model_path: model_store/fastsam/FastSAM-x.pt
+    device: cuda
+    imgsz: 640
+    conf: 0.4
+    iou: 0.9
+
+  yoloworld:
+    model_path: yolov8x-worldv2.pt    # or local path
+    device: cuda
+    imgsz: 640
+    conf: 0.25
+    iou: 0.7
+    with_masks: true                  # generate masks (slower) or boxes only
+    # Custom vocabulary for task-specific detection (null = use default indoor vocab)
+    vocab: null
+    # Example warehouse vocab:
+    # vocab:
+    #   - pallet
+    #   - cardboard box
+    #   - forklift
+    #   - person
+    #   - shelf
+    #   - bin
+
 clip:
   model: ViT-B-32
   pretrained: openai

--- a/config/rtsm.yaml
+++ b/config/rtsm.yaml
@@ -50,9 +50,20 @@ clip:
 
 # -------------------- I/O & Network --------------------
 io:
-  # ZMQ endpoints for dual-socket subscription
-  camera_endpoint: tcp://172.27.240.1:5555    # D435i camera.rgbd topic
-  rtabmap_endpoint: tcp://127.0.0.1:6000      # RTABMap pose topics
+  # Receiver backend: zeromq (D435i + RTABMap) or websocket (Calabi Lens ARKit)
+  receiver: zeromq                              # zeromq | websocket
+
+  # ZMQ endpoints for dual-socket subscription (only when receiver: zeromq)
+  camera_endpoint: tcp://172.27.240.1:5555      # D435i camera.rgbd topic
+  rtabmap_endpoint: tcp://127.0.0.1:6000        # RTABMap pose topics
+
+  # WebSocket receiver config (only when receiver: websocket)
+  websocket:
+    host: "0.0.0.0"
+    port: 8765
+    require_tracking_normal: true               # drop frames where tracking_state != "normal"
+    keyframe_every_n: 30                        # mark every Nth frame as keyframe
+    nonkf_min_interval_s: 0.5                   # throttle non-KF to max ~2/s
 
 units:
   # Convert incoming values to meters at ingestion

--- a/config/rtsm.yaml
+++ b/config/rtsm.yaml
@@ -51,7 +51,7 @@ clip:
 # -------------------- I/O & Network --------------------
 io:
   # Receiver backend: zeromq (D435i + RTABMap) or websocket (Calabi Lens ARKit)
-  receiver: zeromq                              # zeromq | websocket
+  receiver: websocket                           # zeromq | websocket
 
   # ZMQ endpoints for dual-socket subscription (only when receiver: zeromq)
   camera_endpoint: tcp://172.27.240.1:5555      # D435i camera.rgbd topic

--- a/config/rtsm.yaml
+++ b/config/rtsm.yaml
@@ -64,6 +64,7 @@ io:
     require_tracking_normal: true               # drop frames where tracking_state != "normal"
     keyframe_every_n: 30                        # mark every Nth frame as keyframe
     nonkf_min_interval_s: 0.5                   # throttle non-KF to max ~2/s
+    confidence_threshold: 2                     # 0=accept all, 1=medium+high, 2=high only (2 matches official RTABMap)
 
 units:
   # Convert incoming values to meters at ingestion
@@ -227,11 +228,46 @@ visualization:
   enable: true                    # Enable embedded visualization server
   host: 0.0.0.0
   port: 8081                      # WebSocket port for frontend
+  apply_camera_flip: true           # Flip ARKit camera (Y-up, Z-back) to OpenCV (Y-down, Z-forward)
+
+  # Depth filtering for visualization pipeline
+  depth:
+    min_m: 0.1                    # Minimum depth (meters)
+    max_m: 3.5                    # Maximum depth (meters) - tighter for indoor quality
+
+  # TSDF volumetric fusion (replaces naive per-frame point cloud accumulation)
+  tsdf:
+    enable: true
+    integration_max_width: 640    # Downsample RGB before integration (depth is 256x192)
+    voxel_size: 0.01              # 1cm voxels for indoor
+    sdf_trunc: 0.04               # truncation distance (meters)
+    max_depth_m: 3.5              # max depth for TSDF integration
+    extract_every_n: 30           # extract mesh every N integrated frames
+    extract_interval_s: 2.0       # or extract on timer (seconds), whichever first
+    frame_buffer_size: 200        # ring buffer for re-integration on loop closure
+    correction_reset_threshold_m: 0.05  # if max pose correction > this, reset+re-integrate
 
   # Object overlay settings
   objects:
     push_interval_ms: 200         # How often to push WM objects to clients
     include_proto: true           # Include proto (unconfirmed) objects
+
+# -------------------- SLAM (on-device, via Calabi Lens) --------------------
+# RTAB-Map runs on the iPhone. These settings control how RTSM handles
+# SLAM-corrected poses received from the client.
+slam:
+  # Log pose_source from client (arkit_vio vs rtabmap_slam)
+  log_pose_source: true
+
+  # Accept retroactive pose corrections from on-device SLAM loop closures.
+  # When enabled, the client sends a "pose_corrections" text message after
+  # loop closure, and RTSM updates past keyframe poses in the visualization.
+  accept_pose_corrections: true
+
+  # Also correct WorkingMemory object positions when loop closure corrections
+  # arrive. Each object is corrected using the delta from the spatially
+  # nearest corrected camera position.
+  correct_working_memory: true
 
 # -------------------- Runtime --------------------
 logging:

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -724,7 +724,7 @@ setMode('Free')
 const initialCamPos = camera.position.clone()
 const initialTarget = controls.target.clone()
 
-let flippedX = true, flippedY = true, flippedZ = false
+let flippedX = true, flippedY = true, flippedZ = true
 
 function applyFlipScale() {
   world.scale.set(flippedX ? -1 : 1, flippedY ? -1 : 1, flippedZ ? -1 : 1)

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -724,7 +724,7 @@ setMode('Free')
 const initialCamPos = camera.position.clone()
 const initialTarget = controls.target.clone()
 
-let flippedX = true, flippedY = true, flippedZ = true
+let flippedX = false, flippedY = false, flippedZ = false
 
 function applyFlipScale() {
   world.scale.set(flippedX ? -1 : 1, flippedY ? -1 : 1, flippedZ ? -1 : 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 rtsm-run = "rtsm.run:main"
 
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "faiss-cpu>=1.12.0",
+    "open3d>=0.18.0",
     "psutil>=7.0.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ torchaudio ; sys_platform != "win32"
 open-clip-torch
 faiss-cpu ; sys_platform == "win32"
 faiss-cpu ; sys_platform == "linux"
+open3d>=0.18.0

--- a/rtsm/api/server.py
+++ b/rtsm/api/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 import threading
 from typing import Any, Callable, Optional, Dict, List
@@ -340,13 +341,25 @@ def create_app(
             except Exception as e:
                 result["cleared"]["frame_window"] = {"error": str(e)}
 
-        # Clear VisualizationServer registry (keyframes)
+        # Clear VisualizationServer (registry + TSDF + broadcast clear to clients)
         if reset_components and reset_components.vis_server:
             try:
                 vis = reset_components.vis_server
+                vis_result = {}
                 if hasattr(vis, 'registry') and vis.registry:
                     kf_cleared = vis.registry.clear()
-                    result["cleared"]["visualization"] = {"keyframes_cleared": kf_cleared}
+                    vis_result["keyframes_cleared"] = kf_cleared
+                if hasattr(vis, 'tsdf') and vis.tsdf is not None:
+                    vis.tsdf.reset()
+                    vis_result["tsdf_reset"] = True
+                # Broadcast clear to all connected web clients
+                if hasattr(vis, 'broadcaster') and vis._loop and vis._running:
+                    asyncio.run_coroutine_threadsafe(
+                        vis.broadcaster._broadcast_json({"type": "clear"}),
+                        vis._loop,
+                    )
+                    vis_result["clients_notified"] = True
+                result["cleared"]["visualization"] = vis_result
             except Exception as e:
                 result["cleared"]["visualization"] = {"error": str(e)}
 

--- a/rtsm/core/association.py
+++ b/rtsm/core/association.py
@@ -44,6 +44,8 @@ class AssocUpdate:
     crop: Optional[np.ndarray] = None
     # keyframe flag for EMA weighting (keyframes dominate position smoothing)
     is_keyframe: bool = False
+    # frame_id for precise pose correction tracking in WM
+    frame_id: Optional[str] = None
 
 # ---------- math helpers ----------
 
@@ -86,7 +88,7 @@ class Associator:
     def __init__(self, cfg: Dict[str, Any]) -> None:
         self.cfg = cfg
 
-    def update_with_candidates(self, cands, snap, wm, index, *, per_cell_spawn_counter: Optional[Dict[Tuple[int, int, int] | Tuple[int, int], int]] = None, is_keyframe: bool = False) -> Dict[str, int]:
+    def update_with_candidates(self, cands, snap, wm, index, *, per_cell_spawn_counter: Optional[Dict[Tuple[int, int, int] | Tuple[int, int], int]] = None, is_keyframe: bool = False, frame_id: Optional[str] = None) -> Dict[str, int]:
         """Process a batch of Candidates for one Snapshot.
         - cands: iterable of Candidate (duck-typed: .stats.centroid_cam, .emb_vis, .stats.centroid_px, .priority)
         - snap: Snapshot (duck-typed: .pose_cam_T_world [4x4], .intrinsics {fx,fy,cx,cy})
@@ -299,6 +301,7 @@ class Associator:
                     label_topk=getattr(c, 'label_topk', None),
                     crop=getattr(c, 'crop', None),
                     is_keyframe=is_keyframe,
+                    frame_id=frame_id,
                 )
                 wm.update_object(best_id, assoc_update)
                 wm.maybe_promote(best_id)
@@ -320,6 +323,7 @@ class Associator:
                 view_dir_cam=(p_cam.astype(np.float32) / (np.linalg.norm(p_cam) + 1e-12)),
                 centroid_px=getattr(c.stats, 'centroid_px', None),
                 crop=getattr(c, 'crop', None),
+                frame_id=frame_id,
             )
             # No promote here; will happen after subsequent matches
             if oid is not None:

--- a/rtsm/core/datamodel.py
+++ b/rtsm/core/datamodel.py
@@ -142,6 +142,8 @@ class FramePacket:
     pose: Optional[PoseStamped]
     intr: Optional[PinholeIntrinsics]
     is_keyframe: bool = False
+    confidence: Optional[NDArray[np.uint8]] = None  # (H,W) uint8 ARKit confidence 0/1/2
+    device_orientation: Optional[str] = None  # "portrait", "landscapeRight", "landscapeLeft", "portraitUpsideDown"
 
     # convenience helpers
     @property

--- a/rtsm/core/pipeline.py
+++ b/rtsm/core/pipeline.py
@@ -10,6 +10,7 @@ from PIL import Image
 
 from rtsm.utils.mask_staging import run_heuristics, MaskStats
 from rtsm.utils.prepare_ann import prepare_ann
+from rtsm.utils.transforms import orientation_to_rot90_k, rotate_image, unrotate_masks
 from rtsm.utils.periodic_logger import PeriodicLogger
 from rtsm.models.segmentation import SegmentationAdapter, SegmentationResult
 from rtsm.models.clip.adapter import CLIPAdapter
@@ -125,7 +126,8 @@ class Pipeline:
                 H, W = snap.rgb.shape[:2]
                 Z = None
                 if snap.depth_m is not None:
-                    zc = float(snap.depth_m[H//2, W//2])
+                    dH, dW = snap.depth_m.shape[:2]
+                    zc = float(snap.depth_m[dH//2, dW//2])
                     if np.isfinite(zc) and zc > 0:
                         Z = zc
                 ts_ns = int(pkt.time.t_sensor_ns or 0)
@@ -167,9 +169,14 @@ class Pipeline:
             return
 
         # 1) segmentation -> masks
-        # SegmentationAdapter expects a PIL.Image
-        rgb_img = snap.rgb
-        pil_img = Image.fromarray(rgb_img) if isinstance(rgb_img, np.ndarray) else rgb_img
+        # Determine ML rotation from device orientation (opt-in: no rotation when absent)
+        rot_k = 0
+        if pkt is not None:
+            rot_k = orientation_to_rot90_k(getattr(pkt, 'device_orientation', None))
+
+        # SegmentationAdapter expects a PIL.Image — rotate to gravity-aligned for ML
+        rgb_for_seg = rotate_image(snap.rgb, rot_k) if rot_k else snap.rgb
+        pil_img = Image.fromarray(rgb_for_seg) if isinstance(rgb_for_seg, np.ndarray) else rgb_for_seg
 
         # Get segmentation vocab from config (for open-vocab models like YOLO-World)
         seg_cfg = self.cfg.get("segmentation", {})
@@ -185,28 +192,78 @@ class Pipeline:
             # Fallback for detection-only models (no masks)
             ann_bool = torch.empty(0, pil_img.height, pil_img.width, dtype=torch.bool)
 
+        # Rotate masks back to original sensor space (geometry stays untouched)
+        if rot_k and ann_bool.shape[0] > 0:
+            ann_bool = unrotate_masks(ann_bool, rot_k)
+
+        if rot_k:
+            logger.debug(f"[pipeline] applied {rot_k*90}° CCW rotation for {pkt.device_orientation} orientation")
+
         n_masks = int(ann_bool.shape[0]) if hasattr(ann_bool, 'shape') else 0
 
         # 2) heuristics -> keep + stats
+        #    Overlay per-frame intrinsics so mask staging uses the actual camera,
+        #    not the static YAML defaults (critical for WebSocket/ARKit path).
+        heur_cfg = self.cfg
+        if snap.intrinsics:
+            heur_cfg = {**self.cfg, "camera": {**self.cfg.get("camera", {}), **snap.intrinsics}}
+            # Also propagate width/height from the actual frame
+            h_frame, w_frame = snap.rgb.shape[:2]
+            heur_cfg["camera"]["width"] = w_frame
+            heur_cfg["camera"]["height"] = h_frame
+        # Safety: if mask resolution differs from RGB (e.g. retina_masks=False
+        # or a different segmentation backend), scale intrinsics to mask space
+        # so _centroid_cam back-projects with consistent coordinates.
+        mask_hw = None
+        if ann_bool.shape[0] > 0:
+            mask_h, mask_w = ann_bool.shape[1], ann_bool.shape[2]
+            rgb_h_frame, rgb_w_frame = snap.rgb.shape[:2]
+            if mask_h != rgb_h_frame or mask_w != rgb_w_frame:
+                mask_hw = (mask_h, mask_w)
+                sx = mask_w / rgb_w_frame
+                sy = mask_h / rgb_h_frame
+                cam = heur_cfg.get("camera", {})
+                heur_cfg = {**heur_cfg, "camera": {
+                    **cam,
+                    "fx": float(cam.get("fx", 0)) * sx,
+                    "fy": float(cam.get("fy", 0)) * sy,
+                    "cx": float(cam.get("cx", 0)) * sx,
+                    "cy": float(cam.get("cy", 0)) * sy,
+                    "width": mask_w,
+                    "height": mask_h,
+                }}
+                logger.debug(
+                    f"mask/RGB resolution mismatch ({mask_w}x{mask_h} vs "
+                    f"{rgb_w_frame}x{rgb_h_frame}), scaled intrinsics to mask space"
+                )
+
         kept_masks, stats = run_heuristics(
             ann_bool,
             snap.depth_m,
-            cfg=self.cfg,
+            cfg=heur_cfg,
         )
         logger.debug(f"staging: kept {len(kept_masks)}/{n_masks} masks after heuristics")
 
         # 3) compute priorities (soft-features) and pick top-K
-        cands = self._score_and_select(kept_masks, stats)
-        
+        #    Use mask resolution for frame_hw when masks differ from RGB
+        select_hw = mask_hw if mask_hw else snap.rgb.shape[:2]
+        cands = self._score_and_select(kept_masks, stats, frame_hw=select_hw)
+
         # 4) pre-CLIP crop only top-K, then batch encode
-        self._make_crops_inplace(cands, snap.rgb)
+        #    Crops are extracted from original (sensor-space) RGB, then rotated
+        #    to gravity-aligned for better CLIP classification quality.
+        self._make_crops_inplace(cands, snap.rgb, rot_k=rot_k)
         self._clip_batch_inplace(cands)
 
         # 5) associate and update memory/index (if components provided)
         m, c = 0, 0
         is_kf = bool(pkt.is_keyframe) if pkt is not None else False
+        # Build frame_id for WM pose correction tracking (matches vis server mesh_id)
+        frame_id = None
+        if pkt is not None and pkt.time.seq is not None:
+            frame_id = f"ws_{pkt.time.seq}"
         if self.associator is not None and self.working_mem is not None and self.proximity_index is not None:
-            stats_assoc = self.associator.update_with_candidates(cands, snap, self.working_mem, self.proximity_index, is_keyframe=is_kf)
+            stats_assoc = self.associator.update_with_candidates(cands, snap, self.working_mem, self.proximity_index, is_keyframe=is_kf, frame_id=frame_id)
             try:
                 if isinstance(stats_assoc, dict):
                     m = int(stats_assoc.get("matched", 0))
@@ -266,7 +323,9 @@ class Pipeline:
         try:
             if pkt.pose is not None:
                 T_wc = pkt.pose.T_wc()
-                # Debug: log T_wc before inversion (periodically)
+                # Note: ARKit→OpenCV camera flip is applied at ingestion
+                # (WebSocketReceiver) so T_wc is already in OpenCV convention.
+                # Debug: log T_wc (periodically)
                 if not hasattr(self, '_pipe_pose_log_count'):
                     self._pipe_pose_log_count = 0
                 self._pipe_pose_log_count += 1
@@ -274,7 +333,7 @@ class Pipeline:
                     t_raw = pkt.pose.t_wc
                     t_from_matrix = T_wc[:3, 3]
                     logger.debug(f"[pipeline] pkt.pose.t_wc={t_raw}, T_wc[:3,3]={t_from_matrix}")
-                # inverse to get T_cam_world
+                # inverse to get T_cam_world (maps world → OpenCV camera frame)
                 R = T_wc[:3, :3]
                 t = T_wc[:3, 3]
                 T = np.eye(4, dtype=np.float32)
@@ -285,7 +344,8 @@ class Pipeline:
         return Snapshot(rgb=rgb, depth_m=depth_m, intrinsics=intr, pose_cam_T_world=T), pkt
 
     def _score_and_select(
-        self, masks: List[torch.Tensor], stats: List[MaskStats]
+        self, masks: List[torch.Tensor], stats: List[MaskStats],
+        frame_hw: Optional[Tuple[int, int]] = None,
     ) -> List[Candidate]:
         """
         This function takes a list of candidate masks and their computed statistics,
@@ -309,7 +369,10 @@ class Pipeline:
         The returned list is sorted in descending order of priority.
         """
         
-        H, W = self.cfg.get("camera",{}).get("height"), self.cfg.get("camera",{}).get("width")
+        if frame_hw is not None:
+            H, W = frame_hw
+        else:
+            H, W = self.cfg.get("camera",{}).get("height"), self.cfg.get("camera",{}).get("width")
         # weights from cfg with safe defaults
         w_cov   = float(self.cfg.get("staging",{}).get("w_coverage", 1.0))
         w_edge  = float(self.cfg.get("staging",{}).get("w_border_fraction", -2.0))
@@ -434,11 +497,11 @@ class Pipeline:
 
         return kept[:topK]
 
-    def _make_crops_inplace(self, cands: List[Candidate], rgb: np.ndarray):
+    def _make_crops_inplace(self, cands: List[Candidate], rgb: np.ndarray, rot_k: int = 0):
         pad = int(self.cfg.get("staging",{}).get("crop_pad_px", 6))
         size = int(self.cfg.get("staging",{}).get("clip_input", 224))
         H, W, _ = rgb.shape
-        
+
         for c in cands:
             x0, y0, x1, y1 = c.stats.bbox  # x1/y1 are exclusive (as we computed earlier)
 
@@ -455,6 +518,10 @@ class Pipeline:
             if crop.size == 0:
                 c.crop = None
                 continue
+
+            # Rotate crop to gravity-aligned for better CLIP quality
+            if rot_k:
+                crop = rotate_image(crop, rot_k)
 
             crop = cv2.resize(crop, (size, size), interpolation=cv2.INTER_LINEAR)
             c.crop = crop

--- a/rtsm/io/websocket.py
+++ b/rtsm/io/websocket.py
@@ -38,9 +38,14 @@ logger = logging.getLogger(__name__)
 PROTOCOL_VERSION = 1
 
 # Supported format values
-_RGB_FORMATS = {"jpeg", "png", "bgra"}
+_RGB_FORMATS = {"jpeg", "png", "bgra", "nv12"}
 _DEPTH_FORMATS = {"uint16_mm", "float32_m", "png_uint16"}
 _POSE_FORMATS = {"matrix4x4_col_major", "quat_translation"}
+
+# ARKit camera (Y-up, Z-toward-viewer) → OpenCV camera (Y-down, Z-forward)
+# Right-multiplying T_wc by this converts camera columns from ARKit to OpenCV
+# convention. diag(1, -1, -1, 1) is its own inverse.
+_ARKIT_TO_OPENCV = np.diag([1.0, -1.0, -1.0, 1.0]).astype(np.float32)
 
 
 # ─────────────────── Data Conversion Functions ───────────────────
@@ -52,7 +57,7 @@ def decode_rgb(raw: bytes, fmt: str, width: int, height: int) -> np.ndarray:
 
     Args:
         raw: Raw byte payload.
-        fmt: ``"jpeg"`` | ``"png"`` | ``"bgra"``.
+        fmt: ``"jpeg"`` | ``"png"`` | ``"bgra"`` | ``"nv12"``.
         width, height: Expected image dimensions.
 
     Returns:
@@ -76,6 +81,17 @@ def decode_rgb(raw: bytes, fmt: str, width: int, height: int) -> np.ndarray:
             )
         img = np.frombuffer(raw, dtype=np.uint8).reshape(height, width, 4)
         return cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+    elif fmt == "nv12":
+        # NV12: Y plane (H*W) + interleaved UV plane (H/2 * W)
+        # Total bytes = H * W * 3 / 2
+        expected = height * width * 3 // 2
+        if len(raw) != expected:
+            raise ValueError(
+                f"nv12 buffer size mismatch: got {len(raw)}, "
+                f"expected {expected} ({width}x{height} * 1.5)"
+            )
+        yuv = np.frombuffer(raw, dtype=np.uint8).reshape(height * 3 // 2, width)
+        return cv2.cvtColor(yuv, cv2.COLOR_YUV2BGR_NV12)
     else:
         raise ValueError(f"Unsupported rgb_format: {fmt!r}")
 
@@ -196,7 +212,11 @@ class WebSocketReceiver:
         require_tracking_normal: bool = True,
         keyframe_every_n: int = 30,
         nonkf_min_interval_s: float = 0.5,
+        confidence_threshold: int = 1,
+        apply_camera_flip: bool = False,
         on_keyframe: Optional[callable] = None,
+        on_pose_corrections: Optional[callable] = None,
+        on_pose_corrections_batch: Optional[callable] = None,
     ) -> None:
         self.ingest_q = ingest_queue
         self._host = host
@@ -204,7 +224,11 @@ class WebSocketReceiver:
         self._require_tracking_normal = require_tracking_normal
         self._keyframe_every_n = max(1, keyframe_every_n)
         self._nonkf_min_interval_s = nonkf_min_interval_s
+        self._confidence_threshold = confidence_threshold
+        self._apply_camera_flip = apply_camera_flip
         self._on_keyframe = on_keyframe
+        self._on_pose_corrections = on_pose_corrections
+        self._on_pose_corrections_batch = on_pose_corrections_batch
 
         # Per-session state (reset on each new client connection)
         self._frame_count: int = 0
@@ -294,37 +318,47 @@ class WebSocketReceiver:
         frames_enqueued = 0
         t_start = time.monotonic()
 
-        # ── Binary receive loop ──
+        # ── Receive loop (binary frames + text messages) ──
         try:
             while True:
-                data = await ws.receive_bytes()
-                frames_received += 1
-                try:
-                    pkt = self._parse_binary_message(data)
-                    if pkt is not None:
-                        ok = self.ingest_q.put(pkt, block=False)
-                        if ok:
-                            frames_enqueued += 1
-                            self._last_enq_ts_ns = pkt.time.t_sensor_ns
-                            if not pkt.is_keyframe:
-                                self._last_nonkf_enq_mono = time.monotonic()
-                            # Forward keyframes to visualization server
-                            if pkt.is_keyframe and self._on_keyframe is not None:
-                                try:
-                                    self._on_keyframe(pkt)
-                                except Exception as e:
-                                    logger.error(f"[websocket] on_keyframe callback error: {e}")
-                            frame_type = "KF" if pkt.is_keyframe else "frame"
-                            logger.debug(
-                                f"[websocket] enqueued {frame_type} "
-                                f"-> queue={self.ingest_q.qsize()}"
-                            )
-                        else:
-                            logger.warning(
-                                "[websocket] ingest queue full; dropping frame"
-                            )
-                except Exception as e:
-                    logger.error(f"[websocket] frame parse error: {e}")
+                msg = await ws.receive()
+                if msg["type"] == "websocket.receive":
+                    if "bytes" in msg and msg["bytes"]:
+                        # Binary frame
+                        frames_received += 1
+                        try:
+                            pkt = self._parse_binary_message(msg["bytes"])
+                            if pkt is not None:
+                                ok = self.ingest_q.put(pkt, block=False)
+                                if ok:
+                                    frames_enqueued += 1
+                                    self._last_enq_ts_ns = pkt.time.t_sensor_ns
+                                    if not pkt.is_keyframe:
+                                        self._last_nonkf_enq_mono = time.monotonic()
+                                    if pkt.is_keyframe and self._on_keyframe is not None:
+                                        try:
+                                            self._on_keyframe(pkt)
+                                        except Exception as e:
+                                            logger.error(f"[websocket] on_keyframe callback error: {e}")
+                                    frame_type = "KF" if pkt.is_keyframe else "frame"
+                                    logger.debug(
+                                        f"[websocket] enqueued {frame_type} "
+                                        f"-> queue={self.ingest_q.qsize()}"
+                                    )
+                                else:
+                                    logger.warning(
+                                        "[websocket] ingest queue full; dropping frame"
+                                    )
+                        except Exception as e:
+                            logger.error(f"[websocket] frame parse error: {e}")
+                    elif "text" in msg and msg["text"]:
+                        # Text message (pose_corrections, etc.)
+                        try:
+                            self._handle_text_message(msg["text"])
+                        except Exception as e:
+                            logger.error(f"[websocket] text message error: {e}")
+                elif msg["type"] == "websocket.disconnect":
+                    break
         except WebSocketDisconnect:
             pass
         except Exception as e:
@@ -337,6 +371,63 @@ class WebSocketReceiver:
                 f"{elapsed:.1f}s duration"
             )
             self._active_session_id = None
+
+    # ── Text message handling ──
+
+    def _handle_text_message(self, text: str) -> None:
+        """Handle a JSON text message (e.g. pose_corrections from RTAB-Map)."""
+        msg = json.loads(text)
+        msg_type = msg.get("type")
+
+        if msg_type == "pose_corrections":
+            corrections = msg.get("corrections", {})
+            if not corrections:
+                return
+
+            # Build full corrections dict (apply camera flip if active)
+            batch = {}
+            for kf_id, pose_data in corrections.items():
+                pose_4x4 = self._corrections_pose_to_4x4(pose_data)
+                if pose_4x4 is not None:
+                    if self._apply_camera_flip:
+                        pose_4x4 = pose_4x4 @ _ARKIT_TO_OPENCV
+                    batch[kf_id] = pose_4x4
+
+            if not batch:
+                return
+
+            # Prefer batch callback (TSDF), fall back to per-correction
+            if self._on_pose_corrections_batch is not None:
+                self._on_pose_corrections_batch(batch)
+            elif self._on_pose_corrections is not None:
+                for kf_id, pose in batch.items():
+                    self._on_pose_corrections(kf_id, pose)
+            else:
+                logger.debug("[websocket] pose_corrections received but no callback registered")
+                return
+
+            logger.info(f"[websocket] Applied {len(batch)} pose corrections (loop closure)")
+        else:
+            logger.debug(f"[websocket] Ignoring text message type: {msg_type}")
+
+    @staticmethod
+    def _corrections_pose_to_4x4(pose_data: list) -> Optional[np.ndarray]:
+        """Convert pose correction data to a 4x4 row-major matrix."""
+        if len(pose_data) == 16:
+            # Column-major 4x4 (same as ARKit binary frames)
+            return np.array(pose_data, dtype=np.float32).reshape(4, 4, order="F")
+        elif len(pose_data) == 7:
+            # [qx, qy, qz, qw, tx, ty, tz]
+            from scipy.spatial.transform import Rotation
+            qx, qy, qz, qw, tx, ty, tz = pose_data
+            R = Rotation.from_quat([qx, qy, qz, qw]).as_matrix()
+            mat = np.eye(4, dtype=np.float32)
+            mat[:3, :3] = R
+            mat[:3, 3] = [tx, ty, tz]
+            return mat
+        else:
+            logger.warning(f"[websocket] pose_corrections: unexpected {len(pose_data)} elements, skipping")
+            return None
 
     # ── Binary message parsing ──
 
@@ -379,8 +470,25 @@ class WebSocketReceiver:
             logger.warning("[websocket] message truncated at depth payload")
             return None
         depth_bytes = data[offset : offset + depth_len]
+        offset += depth_len
 
-        # 4. Tracking state filter
+        # 4. Confidence payload (optional � backward compatible)
+        confidence_m = None
+        confidence_fmt = header.get("confidence_format")
+        if confidence_fmt is not None and (n - offset) >= 4:
+            (conf_len,) = struct.unpack_from("<I", data, offset)
+            offset += 4
+            if conf_len > 0 and (n - offset) >= conf_len:
+                conf_bytes = data[offset : offset + conf_len]
+                offset += conf_len
+                conf_w = int(header.get("confidence_width", 0) or 0)
+                conf_h = int(header.get("confidence_height", 0) or 0)
+                if conf_w > 0 and conf_h > 0 and len(conf_bytes) == conf_w * conf_h:
+                    confidence_m = np.frombuffer(
+                        conf_bytes, dtype=np.uint8
+                    ).reshape(conf_h, conf_w)
+
+        # 5. Tracking state filter
         tracking_state = header.get("tracking_state", "not_available")
         if self._require_tracking_normal and tracking_state != "normal":
             logger.debug(
@@ -424,6 +532,16 @@ class WebSocketReceiver:
             pose_format=header.get("pose_format", "matrix4x4_col_major"),
         )
 
+        # 9b. Camera convention flip: ARKit (Y-up, Z-back) → OpenCV (Y-down, Z-forward)
+        # Applied once at ingestion so ALL downstream consumers (pipeline, TSDF,
+        # visualization, sweep cache) see poses in OpenCV camera convention.
+        if self._apply_camera_flip:
+            T_wc_mat = PoseStamped(
+                stamp_ns=0, frame_id="", t_wc=t_wc, q_wc_xyzw=q_xyzw
+            ).T_wc() @ _ARKIT_TO_OPENCV
+            t_wc = T_wc_mat[:3, 3].astype(np.float32)
+            q_xyzw = rotmat_to_quat_xyzw(T_wc_mat[:3, :3].astype(np.float32))
+
         # 10. Build intrinsics (scale if intrinsics resolution differs from RGB)
         intr_w = int(header.get("intrinsics_width", rgb_w))
         intr_h = int(header.get("intrinsics_height", rgb_h))
@@ -465,7 +583,24 @@ class WebSocketReceiver:
             q_wc_xyzw=q_xyzw,
         )
 
-        # 13. Build FramePacket
+        # 13. Apply confidence filtering (if confidence map available)
+        if confidence_m is not None and depth_m is not None and self._confidence_threshold > 0:
+            # Resize confidence to depth resolution if needed
+            dep_h, dep_w = depth_m.shape[:2]
+            conf_h, conf_w = confidence_m.shape[:2]
+            if conf_h != dep_h or conf_w != dep_w:
+                confidence_m = cv2.resize(
+                    confidence_m, (dep_w, dep_h),
+                    interpolation=cv2.INTER_NEAREST
+                )
+            # Zero out low-confidence depth pixels
+            low_conf = confidence_m < self._confidence_threshold
+            depth_m[low_conf] = np.nan
+
+        # 14. Parse device orientation (optional — old clients may not send this)
+        device_orientation = header.get("device_orientation")
+
+        # 15. Build FramePacket
         return FramePacket(
             time=tb,
             rgb=rgb,
@@ -473,6 +608,8 @@ class WebSocketReceiver:
             pose=pose,
             intr=intr,
             is_keyframe=is_keyframe,
+            confidence=confidence_m,
+            device_orientation=device_orientation,
         )
 
     # ── Server lifecycle ──

--- a/rtsm/io/websocket.py
+++ b/rtsm/io/websocket.py
@@ -196,6 +196,7 @@ class WebSocketReceiver:
         require_tracking_normal: bool = True,
         keyframe_every_n: int = 30,
         nonkf_min_interval_s: float = 0.5,
+        on_keyframe: Optional[callable] = None,
     ) -> None:
         self.ingest_q = ingest_queue
         self._host = host
@@ -203,6 +204,7 @@ class WebSocketReceiver:
         self._require_tracking_normal = require_tracking_normal
         self._keyframe_every_n = max(1, keyframe_every_n)
         self._nonkf_min_interval_s = nonkf_min_interval_s
+        self._on_keyframe = on_keyframe
 
         # Per-session state (reset on each new client connection)
         self._frame_count: int = 0
@@ -306,6 +308,12 @@ class WebSocketReceiver:
                             self._last_enq_ts_ns = pkt.time.t_sensor_ns
                             if not pkt.is_keyframe:
                                 self._last_nonkf_enq_mono = time.monotonic()
+                            # Forward keyframes to visualization server
+                            if pkt.is_keyframe and self._on_keyframe is not None:
+                                try:
+                                    self._on_keyframe(pkt)
+                                except Exception as e:
+                                    logger.error(f"[websocket] on_keyframe callback error: {e}")
                             frame_type = "KF" if pkt.is_keyframe else "frame"
                             logger.debug(
                                 f"[websocket] enqueued {frame_type} "

--- a/rtsm/io/websocket.py
+++ b/rtsm/io/websocket.py
@@ -1,0 +1,506 @@
+"""
+WebSocket Receiver for RTSM — Calabi Lens ARKit Client Integration.
+
+Accepts binary frames over ws://host:port/stream from the Calabi Lens iOS app.
+Each frame contains bundled RGB + depth + pose + intrinsics.
+
+Protocol:
+1. Client connects to /stream
+2. Client sends JSON text hello: {"type": "hello", "protocol_version": 1, ...}
+3. Server replies with JSON text ack: {"type": "hello_ack", "status": "ok", ...}
+4. Client streams binary frames (length-prefixed: [json][rgb][depth])
+"""
+
+from __future__ import annotations
+import asyncio
+import json
+import struct
+import time
+import threading
+import logging
+from typing import Optional, Tuple
+
+import numpy as np
+import cv2
+
+from rtsm.core.datamodel import (
+    FramePacket, TimeBundle, PoseStamped, PinholeIntrinsics,
+)
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+
+from rtsm.io.ingest_queue import IngestQueue
+from rtsm.utils.transforms import rotmat_to_quat_xyzw
+
+logger = logging.getLogger(__name__)
+
+# Current handshake protocol version
+PROTOCOL_VERSION = 1
+
+# Supported format values
+_RGB_FORMATS = {"jpeg", "png", "bgra"}
+_DEPTH_FORMATS = {"uint16_mm", "float32_m", "png_uint16"}
+_POSE_FORMATS = {"matrix4x4_col_major", "quat_translation"}
+
+
+# ─────────────────── Data Conversion Functions ───────────────────
+
+
+def decode_rgb(raw: bytes, fmt: str, width: int, height: int) -> np.ndarray:
+    """
+    Decode RGB bytes into (H, W, 3) uint8 BGR array (OpenCV convention).
+
+    Args:
+        raw: Raw byte payload.
+        fmt: ``"jpeg"`` | ``"png"`` | ``"bgra"``.
+        width, height: Expected image dimensions.
+
+    Returns:
+        (H, W, 3) uint8 BGR array.
+
+    Raises:
+        ValueError: On unsupported format or decode failure.
+    """
+    if fmt in ("jpeg", "png"):
+        buf = np.frombuffer(raw, dtype=np.uint8)
+        img = cv2.imdecode(buf, cv2.IMREAD_COLOR)
+        if img is None:
+            raise ValueError(f"cv2.imdecode failed for {fmt} ({len(raw)} bytes)")
+        return img
+    elif fmt == "bgra":
+        expected = height * width * 4
+        if len(raw) != expected:
+            raise ValueError(
+                f"bgra buffer size mismatch: got {len(raw)}, "
+                f"expected {expected} ({width}x{height}x4)"
+            )
+        img = np.frombuffer(raw, dtype=np.uint8).reshape(height, width, 4)
+        return cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+    else:
+        raise ValueError(f"Unsupported rgb_format: {fmt!r}")
+
+
+def decode_depth(
+    raw: bytes,
+    fmt: Optional[str],
+    width: int,
+    height: int,
+    depth_scale: Optional[float] = None,
+) -> Optional[np.ndarray]:
+    """
+    Decode depth bytes into (H, W) float32 meters with NaN for invalid pixels.
+
+    Wire convention: 0 = invalid.  After this function: NaN = invalid.
+
+    Args:
+        raw: Raw byte payload (may be empty if no depth).
+        fmt: ``"uint16_mm"`` | ``"float32_m"`` | ``"png_uint16"`` | ``None``.
+        width, height: Expected depth dimensions.
+        depth_scale: Scale factor (0.001 for mm→m).  Used for uint16 formats.
+
+    Returns:
+        (H, W) float32 array in meters (NaN = invalid), or ``None``.
+    """
+    if fmt is None or len(raw) == 0:
+        return None
+
+    if depth_scale is None:
+        depth_scale = 0.001  # default: millimeters
+
+    if fmt == "uint16_mm":
+        depth_u16 = np.frombuffer(raw, dtype=np.uint16).reshape(height, width)
+        depth_m = depth_u16.astype(np.float32) * depth_scale
+        depth_m[depth_u16 == 0] = np.nan
+        return depth_m
+
+    elif fmt == "float32_m":
+        depth_m = np.frombuffer(raw, dtype=np.float32).reshape(height, width).copy()
+        depth_m[depth_m == 0.0] = np.nan
+        return depth_m
+
+    elif fmt == "png_uint16":
+        buf = np.frombuffer(raw, dtype=np.uint8)
+        depth_u16 = cv2.imdecode(buf, cv2.IMREAD_UNCHANGED)
+        if depth_u16 is None:
+            logger.warning("[websocket] failed to decode PNG depth")
+            return None
+        depth_m = depth_u16.astype(np.float32) * depth_scale
+        depth_m[depth_u16 == 0] = np.nan
+        return depth_m
+
+    else:
+        logger.warning(f"[websocket] unsupported depth_format: {fmt!r}")
+        return None
+
+
+def parse_arkit_pose(
+    T_wc_data: list,
+    pose_format: str,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Parse ARKit pose into canonical (t_wc, q_xyzw) format.
+
+    Args:
+        T_wc_data: 16 floats (col-major 4×4) or 7 floats [qx, qy, qz, qw, tx, ty, tz].
+        pose_format: ``"matrix4x4_col_major"`` | ``"quat_translation"``.
+
+    Returns:
+        ``(t_wc, q_xyzw)`` — both ``np.float32`` arrays, shapes (3,) and (4,).
+
+    Raises:
+        ValueError: On unsupported format or wrong element count.
+    """
+    if pose_format == "quat_translation":
+        if len(T_wc_data) != 7:
+            raise ValueError(
+                f"quat_translation expects 7 elements, got {len(T_wc_data)}"
+            )
+        qx, qy, qz, qw, tx, ty, tz = (float(v) for v in T_wc_data)
+        t_wc = np.array([tx, ty, tz], dtype=np.float32)
+        q_xyzw = np.array([qx, qy, qz, qw], dtype=np.float32)
+        return t_wc, q_xyzw
+
+    elif pose_format == "matrix4x4_col_major":
+        if len(T_wc_data) != 16:
+            raise ValueError(
+                f"matrix4x4_col_major expects 16 elements, got {len(T_wc_data)}"
+            )
+        # Column-major → numpy array with Fortran order
+        mat = np.array(T_wc_data, dtype=np.float64).reshape(4, 4, order="F")
+        t_wc = mat[:3, 3].astype(np.float32)
+        R = mat[:3, :3].astype(np.float32)
+        q_xyzw = rotmat_to_quat_xyzw(R)
+        return t_wc, q_xyzw
+
+    else:
+        raise ValueError(f"Unsupported pose_format: {pose_format!r}")
+
+
+# ─────────────────── WebSocket Receiver Class ───────────────────
+
+
+class WebSocketReceiver:
+    """
+    WebSocket receiver for Calabi Lens ARKit iOS client.
+
+    Accepts binary frames over ``ws://host:port/stream``, decodes them,
+    and enqueues canonical ``FramePacket`` objects to the ingest queue.
+    """
+
+    def __init__(
+        self,
+        ingest_queue: IngestQueue,
+        *,
+        host: str = "0.0.0.0",
+        port: int = 8765,
+        require_tracking_normal: bool = True,
+        keyframe_every_n: int = 30,
+        nonkf_min_interval_s: float = 0.5,
+    ) -> None:
+        self.ingest_q = ingest_queue
+        self._host = host
+        self._port = port
+        self._require_tracking_normal = require_tracking_normal
+        self._keyframe_every_n = max(1, keyframe_every_n)
+        self._nonkf_min_interval_s = nonkf_min_interval_s
+
+        # Per-session state (reset on each new client connection)
+        self._frame_count: int = 0
+        self._last_nonkf_enq_mono: float = 0.0
+        self._last_enq_ts_ns: Optional[int] = None
+        self._active_session_id: Optional[str] = None
+
+        # Threading
+        self._server_thread: Optional[threading.Thread] = None
+        self._shutdown_event = asyncio.Event()
+
+    # ── FastAPI app creation ──
+
+    def _create_app(self):
+        app = FastAPI(title="RTSM WebSocket Receiver")
+
+        @app.get("/health")
+        def health():
+            return JSONResponse({"status": "ok", "receiver": "websocket"})
+
+        @app.websocket("/stream")
+        async def stream_endpoint(ws: WebSocket):
+            await self._handle_stream(ws)
+
+        return app
+
+    # ── Handshake + receive loop ──
+
+    async def _handle_stream(self, ws) -> None:
+        await ws.accept()
+        client_addr = ws.client.host if ws.client else "unknown"
+        logger.info(f"[websocket] Client connected from {client_addr}")
+
+        # ── Handshake: wait for hello ──
+        try:
+            hello_raw = await asyncio.wait_for(ws.receive_text(), timeout=5.0)
+        except asyncio.TimeoutError:
+            logger.warning(f"[websocket] Handshake timeout from {client_addr}")
+            await ws.close(code=4002, reason="handshake timeout")
+            return
+        except Exception:
+            logger.warning(f"[websocket] Connection lost during handshake from {client_addr}")
+            return
+
+        try:
+            hello = json.loads(hello_raw)
+        except json.JSONDecodeError:
+            await ws.close(code=4001, reason="invalid hello JSON")
+            return
+
+        if hello.get("type") != "hello":
+            await ws.close(code=4001, reason="expected hello message")
+            return
+
+        proto_ver = hello.get("protocol_version", 0)
+        if proto_ver != PROTOCOL_VERSION:
+            ack = {
+                "type": "hello_ack",
+                "status": "error",
+                "reason": f"unsupported protocol_version: {proto_ver}",
+            }
+            await ws.send_json(ack)
+            await ws.close(code=4001, reason=ack["reason"])
+            return
+
+        session_id = hello.get("session_id", "unknown")
+        device_name = hello.get("device_name", "unknown")
+        self._active_session_id = session_id
+
+        ack = {
+            "type": "hello_ack",
+            "status": "ok",
+            "protocol_version": PROTOCOL_VERSION,
+            "server": "rtsm",
+            "session_id": session_id,
+        }
+        await ws.send_json(ack)
+        logger.info(
+            f"[websocket] Handshake OK: session={session_id}, device={device_name}"
+        )
+
+        # Reset per-session state
+        self._frame_count = 0
+        self._last_nonkf_enq_mono = 0.0
+        self._last_enq_ts_ns = None
+        frames_received = 0
+        frames_enqueued = 0
+        t_start = time.monotonic()
+
+        # ── Binary receive loop ──
+        try:
+            while True:
+                data = await ws.receive_bytes()
+                frames_received += 1
+                try:
+                    pkt = self._parse_binary_message(data)
+                    if pkt is not None:
+                        ok = self.ingest_q.put(pkt, block=False)
+                        if ok:
+                            frames_enqueued += 1
+                            self._last_enq_ts_ns = pkt.time.t_sensor_ns
+                            if not pkt.is_keyframe:
+                                self._last_nonkf_enq_mono = time.monotonic()
+                            frame_type = "KF" if pkt.is_keyframe else "frame"
+                            logger.debug(
+                                f"[websocket] enqueued {frame_type} "
+                                f"-> queue={self.ingest_q.qsize()}"
+                            )
+                        else:
+                            logger.warning(
+                                "[websocket] ingest queue full; dropping frame"
+                            )
+                except Exception as e:
+                    logger.error(f"[websocket] frame parse error: {e}")
+        except WebSocketDisconnect:
+            pass
+        except Exception as e:
+            logger.error(f"[websocket] connection error: {e}")
+        finally:
+            elapsed = time.monotonic() - t_start
+            logger.info(
+                f"[websocket] Session {session_id} ended: "
+                f"{frames_received} received, {frames_enqueued} enqueued, "
+                f"{elapsed:.1f}s duration"
+            )
+            self._active_session_id = None
+
+    # ── Binary message parsing ──
+
+    def _parse_binary_message(self, data: bytes) -> Optional[FramePacket]:
+        """Parse a single binary WebSocket message into a FramePacket."""
+        offset = 0
+        n = len(data)
+
+        # 1. JSON header
+        if n < 4:
+            logger.warning("[websocket] message too short for json_len")
+            return None
+        (json_len,) = struct.unpack_from("<I", data, offset)
+        offset += 4
+        if n < offset + json_len:
+            logger.warning("[websocket] message truncated at JSON payload")
+            return None
+        header = json.loads(data[offset : offset + json_len].decode("utf-8"))
+        offset += json_len
+
+        # 2. RGB payload
+        if n < offset + 4:
+            logger.warning("[websocket] message truncated at rgb_len")
+            return None
+        (rgb_len,) = struct.unpack_from("<I", data, offset)
+        offset += 4
+        if n < offset + rgb_len:
+            logger.warning("[websocket] message truncated at RGB payload")
+            return None
+        rgb_bytes = data[offset : offset + rgb_len]
+        offset += rgb_len
+
+        # 3. Depth payload
+        if n < offset + 4:
+            logger.warning("[websocket] message truncated at depth_len")
+            return None
+        (depth_len,) = struct.unpack_from("<I", data, offset)
+        offset += 4
+        if n < offset + depth_len:
+            logger.warning("[websocket] message truncated at depth payload")
+            return None
+        depth_bytes = data[offset : offset + depth_len]
+
+        # 4. Tracking state filter
+        tracking_state = header.get("tracking_state", "not_available")
+        if self._require_tracking_normal and tracking_state != "normal":
+            logger.debug(
+                f"[websocket] dropping frame: tracking_state={tracking_state}"
+            )
+            return None
+
+        self._frame_count += 1
+
+        # 5. Keyframe decision
+        is_keyframe = (
+            self._frame_count == 1
+            or self._frame_count % self._keyframe_every_n == 0
+        )
+
+        # 6. Non-KF throttle
+        if not is_keyframe:
+            now_mono = time.monotonic()
+            if (now_mono - self._last_nonkf_enq_mono) < self._nonkf_min_interval_s:
+                return None
+
+        # 7. Decode RGB
+        rgb_fmt = header.get("rgb_format", "jpeg")
+        rgb_w = int(header.get("rgb_width", 0))
+        rgb_h = int(header.get("rgb_height", 0))
+        rgb = decode_rgb(rgb_bytes, fmt=rgb_fmt, width=rgb_w, height=rgb_h)
+
+        # 8. Decode depth (native resolution, NaN for invalid)
+        depth_fmt = header.get("depth_format")
+        depth_w = int(header.get("depth_width", 0) or 0)
+        depth_h = int(header.get("depth_height", 0) or 0)
+        depth_scale = float(header.get("depth_scale", 0.001) or 0.001)
+        depth_m = decode_depth(
+            depth_bytes, fmt=depth_fmt, width=depth_w, height=depth_h,
+            depth_scale=depth_scale,
+        )
+
+        # 9. Parse pose
+        t_wc, q_xyzw = parse_arkit_pose(
+            T_wc_data=header["T_wc"],
+            pose_format=header.get("pose_format", "matrix4x4_col_major"),
+        )
+
+        # 10. Build intrinsics (scale if intrinsics resolution differs from RGB)
+        intr_w = int(header.get("intrinsics_width", rgb_w))
+        intr_h = int(header.get("intrinsics_height", rgb_h))
+        fx = float(header["fx"])
+        fy = float(header["fy"])
+        cx = float(header["cx"])
+        cy = float(header["cy"])
+
+        if intr_w > 0 and intr_h > 0 and rgb_w > 0 and rgb_h > 0:
+            if intr_w != rgb_w or intr_h != rgb_h:
+                scale_x = rgb_w / intr_w
+                scale_y = rgb_h / intr_h
+                fx *= scale_x
+                fy *= scale_y
+                cx *= scale_x
+                cy *= scale_y
+
+        intr = PinholeIntrinsics(
+            width=rgb_w, height=rgb_h,
+            fx=fx, fy=fy, cx=cx, cy=cy,
+        )
+
+        # 11. Build TimeBundle
+        timestamp_ns = int(header.get("timestamp_ns", 0))
+        unix_ts = float(header.get("unix_timestamp", time.time()))
+
+        tb = TimeBundle(
+            t_mono_s=time.monotonic(),
+            t_wall_utc_s=unix_ts,
+            t_sensor_ns=timestamp_ns,
+            seq=int(header.get("frame_id", 0)),
+        )
+
+        # 12. Build PoseStamped
+        pose = PoseStamped(
+            stamp_ns=timestamp_ns,
+            frame_id="arkit",
+            t_wc=t_wc,
+            q_wc_xyzw=q_xyzw,
+        )
+
+        # 13. Build FramePacket
+        return FramePacket(
+            time=tb,
+            rgb=rgb,
+            depth_m=depth_m,
+            pose=pose,
+            intr=intr,
+            is_keyframe=is_keyframe,
+        )
+
+    # ── Server lifecycle ──
+
+    def _run_server(self) -> None:
+        """Run uvicorn in a background thread with its own event loop."""
+        import uvicorn
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+
+        app = self._create_app()
+        config = uvicorn.Config(
+            app,
+            host=self._host,
+            port=self._port,
+            log_level="warning",
+            ws_max_size=16 * 1024 * 1024,  # 16 MB max message
+        )
+        server = uvicorn.Server(config)
+        server.install_signal_handlers = lambda: None  # no signals in child thread
+        loop.run_until_complete(server.serve())
+
+    def start(self) -> None:
+        """Start the WebSocket receiver in a daemon thread."""
+        if self._server_thread and self._server_thread.is_alive():
+            logger.warning("[websocket] Server already running")
+            return
+        self._server_thread = threading.Thread(
+            target=self._run_server,
+            daemon=True,
+            name="websocket-receiver",
+        )
+        self._server_thread.start()
+
+    def stop(self) -> None:
+        """Signal shutdown (best-effort; daemon thread exits with process)."""
+        logger.info("[websocket] Stop requested")

--- a/rtsm/io/zeromq.py
+++ b/rtsm/io/zeromq.py
@@ -309,8 +309,10 @@ class ZeroMQSubscriber:
             map_id = str(metadata.get('map_id', 0))
             timestamp_ns = metadata.get('ts_ns', 0)
 
-            # Parse intrinsics
+            # Parse intrinsics (warn if falling back to defaults)
             intrinsics = metadata.get('intrinsics', {})
+            if not intrinsics or 'fx' not in intrinsics:
+                logger.warning("[zeromq] kf_packet missing intrinsics, using D435i defaults")
             fx = intrinsics.get('fx', 615.0)
             fy = intrinsics.get('fy', 615.0)
             cx = intrinsics.get('cx', 320.0)

--- a/rtsm/models/segmentation/__init__.py
+++ b/rtsm/models/segmentation/__init__.py
@@ -1,0 +1,114 @@
+"""
+Segmentation module with swappable backends.
+
+Usage:
+    from rtsm.models.segmentation import get_segmenter, SegmentationResult
+
+    # Create segmenter from config
+    segmenter = get_segmenter(cfg)
+
+    # Run segmentation
+    result = segmenter.segment(pil_image)
+
+    # Access results
+    print(f"Found {result.count} objects")
+    if result.has_masks:
+        masks = result.masks  # [N, H, W] bool tensor
+    if result.labels:
+        print(f"Labels: {result.labels}")
+"""
+from __future__ import annotations
+from typing import Dict, Any, Optional
+import logging
+
+from rtsm.models.segmentation.base import SegmentationAdapter, SegmentationResult
+
+logger = logging.getLogger(__name__)
+
+# Registry of available backends
+_BACKENDS = {}
+
+
+def register_backend(name: str):
+    """Decorator to register a segmentation backend."""
+    def decorator(cls):
+        _BACKENDS[name] = cls
+        return cls
+    return decorator
+
+
+def get_segmenter(cfg: Dict[str, Any]) -> SegmentationAdapter:
+    """
+    Factory function to create a segmenter from config.
+
+    Config format:
+        segmentation:
+          backend: fastsam | yoloworld
+          fastsam:
+            model_path: model_store/fastsam/FastSAM-x.pt
+            ...
+          yoloworld:
+            model_path: yolov8x-worldv2.pt
+            vocab: [...]
+            ...
+
+    Args:
+        cfg: Full RTSM config dict
+
+    Returns:
+        SegmentationAdapter instance
+    """
+    seg_cfg = cfg.get("segmentation", {})
+    backend = seg_cfg.get("backend", "fastsam")
+
+    logger.info(f"Creating segmenter: backend={backend}")
+
+    if backend == "fastsam":
+        return _create_fastsam(cfg, seg_cfg)
+    elif backend == "yoloworld":
+        return _create_yoloworld(cfg, seg_cfg)
+    else:
+        raise ValueError(
+            f"Unknown segmentation backend: {backend}. "
+            f"Available: fastsam, yoloworld"
+        )
+
+
+def _create_fastsam(cfg: Dict[str, Any], seg_cfg: Dict[str, Any]) -> SegmentationAdapter:
+    """Create FastSAM segmenter from config."""
+    from rtsm.models.segmentation.fastsam_segmenter import FastSAMSegmenter
+
+    fastsam_cfg = seg_cfg.get("fastsam", {})
+
+    return FastSAMSegmenter(
+        model_path=fastsam_cfg.get("model_path", "model_store/fastsam/FastSAM-x.pt"),
+        device=fastsam_cfg.get("device", "cuda"),
+        imgsz=fastsam_cfg.get("imgsz", 640),
+        conf=fastsam_cfg.get("conf", 0.4),
+        iou=fastsam_cfg.get("iou", 0.9),
+    )
+
+
+def _create_yoloworld(cfg: Dict[str, Any], seg_cfg: Dict[str, Any]) -> SegmentationAdapter:
+    """Create YOLO-World segmenter from config."""
+    from rtsm.models.segmentation.yoloworld_segmenter import YOLOWorldSegmenter
+
+    yolo_cfg = seg_cfg.get("yoloworld", {})
+
+    return YOLOWorldSegmenter(
+        model_path=yolo_cfg.get("model_path", "yolov8x-worldv2.pt"),
+        device=yolo_cfg.get("device", "cuda"),
+        imgsz=yolo_cfg.get("imgsz", 640),
+        conf=yolo_cfg.get("conf", 0.25),
+        iou=yolo_cfg.get("iou", 0.7),
+        default_vocab=yolo_cfg.get("vocab", None),
+        with_masks=yolo_cfg.get("with_masks", True),
+    )
+
+
+# Re-export for convenience
+__all__ = [
+    "SegmentationAdapter",
+    "SegmentationResult",
+    "get_segmenter",
+]

--- a/rtsm/models/segmentation/base.py
+++ b/rtsm/models/segmentation/base.py
@@ -1,0 +1,129 @@
+"""
+Abstract base class for segmentation/detection models.
+
+This abstraction allows RTSM to swap between different backends:
+- FastSAM (open-world segmentation)
+- YOLO-World (open-vocabulary detection)
+- Future: 3D-aware segmentation, Grounding DINO + SAM, etc.
+"""
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import List, Optional
+from PIL import Image
+import torch
+import numpy as np
+
+
+@dataclass
+class SegmentationResult:
+    """
+    Unified output format for all segmentation/detection models.
+
+    All fields except `masks` are optional — different models provide different data.
+    The pipeline adapts based on what's available.
+    """
+    # Core outputs (at least one of masks or boxes should be present)
+    masks: Optional[torch.Tensor] = None        # [N, H, W] bool — instance masks
+    boxes: Optional[torch.Tensor] = None        # [N, 4] float — xyxy format
+
+    # Confidence and classification
+    scores: Optional[torch.Tensor] = None       # [N] float — detection confidence
+    labels: Optional[List[str]] = None          # [N] str — class names (open-vocab models)
+    class_ids: Optional[torch.Tensor] = None    # [N] int — class indices into vocabulary
+
+    # Embeddings (if model provides, can skip CLIP)
+    embeddings: Optional[torch.Tensor] = None   # [N, D] float — visual embeddings
+
+    # Metadata
+    vocab: Optional[List[str]] = None           # vocabulary used for detection
+
+    @property
+    def count(self) -> int:
+        """Number of detected instances."""
+        if self.masks is not None:
+            return self.masks.shape[0]
+        if self.boxes is not None:
+            return self.boxes.shape[0]
+        return 0
+
+    @property
+    def has_masks(self) -> bool:
+        return self.masks is not None and self.masks.numel() > 0
+
+    @property
+    def has_boxes(self) -> bool:
+        return self.boxes is not None and self.boxes.numel() > 0
+
+    @property
+    def has_embeddings(self) -> bool:
+        return self.embeddings is not None and self.embeddings.numel() > 0
+
+
+class SegmentationAdapter(ABC):
+    """
+    Abstract base class for segmentation/detection models.
+
+    Implementations:
+    - FastSAMSegmenter: Open-world "segment everything"
+    - YOLOWorldSegmenter: Open-vocabulary detection with optional masks
+    - Future: GroundingDINOSegmenter, SAM2Segmenter, etc.
+    """
+
+    @abstractmethod
+    def segment(
+        self,
+        image: Image.Image,
+        vocab: Optional[List[str]] = None,
+    ) -> SegmentationResult:
+        """
+        Segment/detect objects in the image.
+
+        Args:
+            image: PIL RGB image
+            vocab: Optional list of class names for open-vocabulary models.
+                   Ignored by models that don't support text prompts.
+
+        Returns:
+            SegmentationResult with detected instances
+        """
+        pass
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release model resources (GPU memory, etc.)."""
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Model identifier for logging/config."""
+        pass
+
+    @property
+    def supports_vocab(self) -> bool:
+        """Does this model support open-vocabulary text prompts?"""
+        return False
+
+    @property
+    def provides_embeddings(self) -> bool:
+        """Does this model provide visual embeddings (can skip CLIP)?"""
+        return False
+
+    @property
+    def provides_masks(self) -> bool:
+        """Does this model provide instance masks (vs boxes only)?"""
+        return True
+
+    # Convenience method for backward compatibility
+    def segment_everything(self, image: Image.Image) -> torch.Tensor:
+        """
+        Legacy interface: segment all objects, return masks only.
+
+        Returns:
+            Boolean mask tensor [N, H, W]
+        """
+        result = self.segment(image, vocab=None)
+        if result.masks is not None:
+            return result.masks
+        return torch.empty(0, image.height, image.width, dtype=torch.bool)

--- a/rtsm/models/segmentation/fastsam_segmenter.py
+++ b/rtsm/models/segmentation/fastsam_segmenter.py
@@ -1,0 +1,175 @@
+"""
+FastSAM segmentation backend.
+
+Wraps the existing FastSAM implementation to conform to SegmentationAdapter interface.
+"""
+from __future__ import annotations
+from typing import List, Optional
+from PIL import Image
+import torch
+import logging
+
+from rtsm.models.segmentation.base import SegmentationAdapter, SegmentationResult
+from rtsm.models.fastsam.model import FastSAM
+from rtsm.models.fastsam.prompt import FastSAMPrompt
+
+logger = logging.getLogger(__name__)
+
+
+class FastSAMSegmenter(SegmentationAdapter):
+    """
+    Open-world segmentation using FastSAM.
+
+    Segments "everything" in the image without requiring a vocabulary.
+    Does not provide embeddings — CLIP encoding is done separately in the pipeline.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        device: str = "cuda",
+        imgsz: int = 640,
+        conf: float = 0.4,
+        iou: float = 0.9,
+    ):
+        """
+        Args:
+            model_path: Path to FastSAM weights (e.g., FastSAM-x.pt)
+            device: "cuda" or "cpu"
+            imgsz: Input image size for inference
+            conf: Confidence threshold
+            iou: IoU threshold for NMS
+        """
+        self.model = FastSAM(model_path)
+        self.device = device
+        self.imgsz = imgsz
+        self.conf = conf
+        self.iou = iou
+        logger.info(f"FastSAMSegmenter initialized: device={device}, imgsz={imgsz}")
+
+    def segment(
+        self,
+        image: Image.Image,
+        vocab: Optional[List[str]] = None,
+    ) -> SegmentationResult:
+        """
+        Segment all objects in the image.
+
+        Args:
+            image: PIL RGB image
+            vocab: Ignored — FastSAM doesn't use text prompts
+
+        Returns:
+            SegmentationResult with masks (no labels, no embeddings)
+        """
+        # Run FastSAM inference
+        everything_results = self.model(
+            image,
+            device=self.device,
+            retina_masks=False,
+            imgsz=self.imgsz,
+            conf=self.conf,
+            iou=self.iou,
+            verbose=False,
+        )
+
+        # Process results to get masks
+        prompt_process = FastSAMPrompt(image, everything_results, device=self.device)
+        ann = prompt_process.everything_prompt()
+
+        # Convert to standard format [N, H, W] bool tensor
+        masks = self._convert_annotations(ann, image.size)
+
+        # Extract bounding boxes from masks
+        boxes = self._masks_to_boxes(masks) if masks.numel() > 0 else None
+
+        return SegmentationResult(
+            masks=masks,
+            boxes=boxes,
+            scores=None,  # FastSAM doesn't provide per-mask scores after everything_prompt
+            labels=None,  # No classification
+            embeddings=None,  # Requires separate CLIP encoding
+        )
+
+    def _convert_annotations(
+        self, ann: any, image_size: tuple
+    ) -> torch.Tensor:
+        """Convert FastSAM output to [N, H, W] bool tensor."""
+        W, H = image_size
+
+        if ann is None:
+            return torch.empty(0, H, W, dtype=torch.bool)
+
+        # Handle different annotation formats from FastSAM
+        if isinstance(ann, torch.Tensor):
+            if ann.ndim == 3:
+                return ann.bool()
+            elif ann.ndim == 2:
+                return ann.unsqueeze(0).bool()
+
+        if hasattr(ann, 'shape'):
+            # numpy array
+            import numpy as np
+            if isinstance(ann, np.ndarray):
+                if ann.ndim == 3:
+                    return torch.from_numpy(ann).bool()
+                elif ann.ndim == 2:
+                    return torch.from_numpy(ann).unsqueeze(0).bool()
+
+        # List of masks
+        if isinstance(ann, (list, tuple)) and len(ann) > 0:
+            masks = []
+            for m in ann:
+                if isinstance(m, torch.Tensor):
+                    masks.append(m.bool())
+                else:
+                    masks.append(torch.from_numpy(m).bool())
+            return torch.stack(masks, dim=0)
+
+        return torch.empty(0, H, W, dtype=torch.bool)
+
+    def _masks_to_boxes(self, masks: torch.Tensor) -> torch.Tensor:
+        """Convert masks [N, H, W] to bounding boxes [N, 4] in xyxy format."""
+        if masks.numel() == 0:
+            return torch.empty(0, 4)
+
+        N = masks.shape[0]
+        boxes = []
+
+        for i in range(N):
+            mask = masks[i]
+            if not mask.any():
+                boxes.append([0, 0, 0, 0])
+                continue
+
+            rows = torch.where(mask.any(dim=1))[0]
+            cols = torch.where(mask.any(dim=0))[0]
+
+            y0, y1 = rows[0].item(), rows[-1].item() + 1
+            x0, x1 = cols[0].item(), cols[-1].item() + 1
+            boxes.append([x0, y0, x1, y1])
+
+        return torch.tensor(boxes, dtype=torch.float32)
+
+    def close(self) -> None:
+        """Release model resources."""
+        if hasattr(self.model, 'model'):
+            del self.model.model
+        del self.model
+        torch.cuda.empty_cache()
+
+    @property
+    def name(self) -> str:
+        return "fastsam"
+
+    @property
+    def supports_vocab(self) -> bool:
+        return False
+
+    @property
+    def provides_embeddings(self) -> bool:
+        return False
+
+    @property
+    def provides_masks(self) -> bool:
+        return True

--- a/rtsm/models/segmentation/fastsam_segmenter.py
+++ b/rtsm/models/segmentation/fastsam_segmenter.py
@@ -63,10 +63,13 @@ class FastSAMSegmenter(SegmentationAdapter):
             SegmentationResult with masks (no labels, no embeddings)
         """
         # Run FastSAM inference
+        # retina_masks=True ensures masks are at the original image resolution,
+        # which is required for correct centroid backprojection with per-frame
+        # intrinsics (especially when RGB is 1920x1440 from ARKit).
         everything_results = self.model(
             image,
             device=self.device,
-            retina_masks=False,
+            retina_masks=True,
             imgsz=self.imgsz,
             conf=self.conf,
             iou=self.iou,

--- a/rtsm/models/segmentation/yoloworld_segmenter.py
+++ b/rtsm/models/segmentation/yoloworld_segmenter.py
@@ -1,0 +1,209 @@
+"""
+YOLO-World segmentation/detection backend.
+
+Open-vocabulary object detection with optional SAM-based mask generation.
+"""
+from __future__ import annotations
+from typing import List, Optional, Dict, Any
+from PIL import Image
+import torch
+import numpy as np
+import logging
+
+from rtsm.models.segmentation.base import SegmentationAdapter, SegmentationResult
+
+logger = logging.getLogger(__name__)
+
+
+class YOLOWorldSegmenter(SegmentationAdapter):
+    """
+    Open-vocabulary detection using YOLO-World.
+
+    Unlike FastSAM (segment everything), YOLO-World detects objects
+    from a user-defined vocabulary. This is more reliable for task-specific
+    applications like warehouses where you know what objects to detect.
+
+    Vocabulary can be:
+    - Set at initialization (default_vocab)
+    - Overridden per-call via segment(vocab=...)
+    - Loaded from config
+    """
+
+    def __init__(
+        self,
+        model_path: str = "yolov8x-worldv2.pt",
+        device: str = "cuda",
+        imgsz: int = 640,
+        conf: float = 0.25,
+        iou: float = 0.7,
+        default_vocab: Optional[List[str]] = None,
+        with_masks: bool = True,
+    ):
+        """
+        Args:
+            model_path: Path to YOLO-World weights or model name
+            device: "cuda" or "cpu"
+            imgsz: Input image size for inference
+            conf: Confidence threshold
+            iou: IoU threshold for NMS
+            default_vocab: Default vocabulary if not provided at inference time
+            with_masks: If True, generate masks via SAM head (slower but needed for RTSM)
+        """
+        self.device = device
+        self.imgsz = imgsz
+        self.conf = conf
+        self.iou = iou
+        self.with_masks = with_masks
+        self.default_vocab = default_vocab or self._default_indoor_vocab()
+        self._current_vocab: Optional[List[str]] = None
+
+        # Lazy load model
+        self._model = None
+        self._model_path = model_path
+
+        logger.info(
+            f"YOLOWorldSegmenter initialized: device={device}, imgsz={imgsz}, "
+            f"vocab_size={len(self.default_vocab)}, with_masks={with_masks}"
+        )
+
+    def _default_indoor_vocab(self) -> List[str]:
+        """Default vocabulary for indoor/warehouse scenarios."""
+        return [
+            # Furniture
+            "chair", "table", "desk", "couch", "sofa", "bed", "shelf", "cabinet",
+            # Electronics
+            "monitor", "laptop", "keyboard", "mouse", "phone", "tv", "speaker",
+            # Containers
+            "box", "cardboard box", "bin", "basket", "crate", "pallet",
+            # Common objects
+            "bottle", "cup", "mug", "book", "bag", "backpack", "plant", "lamp",
+            # People/vehicles (optional)
+            "person", "forklift",
+        ]
+
+    def _load_model(self):
+        """Lazy load the YOLO-World model."""
+        if self._model is not None:
+            return
+
+        try:
+            from ultralytics import YOLOWorld
+            self._model = YOLOWorld(self._model_path)
+            self._model.to(self.device)
+            logger.info(f"YOLO-World model loaded: {self._model_path}")
+        except ImportError:
+            raise ImportError(
+                "YOLO-World requires ultralytics package. "
+                "Install with: pip install ultralytics"
+            )
+
+    def _set_vocab(self, vocab: List[str]) -> None:
+        """Set the detection vocabulary (only if changed)."""
+        if self._current_vocab == vocab:
+            return
+        self._model.set_classes(vocab)
+        self._current_vocab = vocab
+        logger.debug(f"YOLO-World vocab set: {len(vocab)} classes")
+
+    def segment(
+        self,
+        image: Image.Image,
+        vocab: Optional[List[str]] = None,
+    ) -> SegmentationResult:
+        """
+        Detect objects from vocabulary in the image.
+
+        Args:
+            image: PIL RGB image
+            vocab: List of class names to detect. If None, uses default_vocab.
+
+        Returns:
+            SegmentationResult with boxes, labels, scores, and optionally masks
+        """
+        self._load_model()
+
+        # Set vocabulary
+        vocab = vocab or self.default_vocab
+        self._set_vocab(vocab)
+
+        # Run inference
+        results = self._model.predict(
+            image,
+            imgsz=self.imgsz,
+            conf=self.conf,
+            iou=self.iou,
+            verbose=False,
+        )
+
+        if not results or len(results) == 0:
+            return self._empty_result(image.size)
+
+        result = results[0]
+
+        # Extract detections
+        boxes = result.boxes.xyxy if result.boxes is not None else None
+        scores = result.boxes.conf if result.boxes is not None else None
+        class_ids = result.boxes.cls if result.boxes is not None else None
+
+        # Map class IDs to labels
+        labels = None
+        if class_ids is not None:
+            labels = [vocab[int(cid)] for cid in class_ids]
+
+        # Extract masks if available
+        masks = None
+        if self.with_masks and hasattr(result, 'masks') and result.masks is not None:
+            masks = torch.from_numpy(result.masks.data).bool()
+
+        # Convert to tensors
+        if boxes is not None and not isinstance(boxes, torch.Tensor):
+            boxes = torch.tensor(boxes)
+        if scores is not None and not isinstance(scores, torch.Tensor):
+            scores = torch.tensor(scores)
+        if class_ids is not None and not isinstance(class_ids, torch.Tensor):
+            class_ids = torch.tensor(class_ids, dtype=torch.int64)
+
+        return SegmentationResult(
+            masks=masks,
+            boxes=boxes,
+            scores=scores,
+            labels=labels,
+            class_ids=class_ids,
+            embeddings=None,  # YOLO-World doesn't expose CLIP-compatible embeddings
+            vocab=vocab,
+        )
+
+    def _empty_result(self, image_size: tuple) -> SegmentationResult:
+        """Return empty result for no detections."""
+        W, H = image_size
+        return SegmentationResult(
+            masks=torch.empty(0, H, W, dtype=torch.bool),
+            boxes=torch.empty(0, 4),
+            scores=torch.empty(0),
+            labels=[],
+            class_ids=torch.empty(0, dtype=torch.int64),
+        )
+
+    def close(self) -> None:
+        """Release model resources."""
+        if self._model is not None:
+            del self._model
+            self._model = None
+        torch.cuda.empty_cache()
+
+    @property
+    def name(self) -> str:
+        return "yoloworld"
+
+    @property
+    def supports_vocab(self) -> bool:
+        return True
+
+    @property
+    def provides_embeddings(self) -> bool:
+        # YOLO-World uses CLIP text encoder but doesn't expose visual embeddings
+        return False
+
+    @property
+    def provides_masks(self) -> bool:
+        return self.with_masks

--- a/rtsm/run.py
+++ b/rtsm/run.py
@@ -49,13 +49,19 @@ def main():
     logger.info(f"Segmentation backend loaded: {segmenter.name}")
     clip = CLIPAdapter("ViT-B-32", "openai", "model_store/clip", device=cfg.get("device","cuda"))
     logger.info(f"CLIP model successfully loaded from model_store/clip")
+    # Determine world-frame up axis from receiver type (ARKit=Y-up, D435i/ROS=Z-up)
+    io_cfg = cfg.get("io", {})
+    receiver_type = str(io_cfg.get("receiver", "zeromq")).lower()
+    up_axis_default = "y" if receiver_type == "websocket" else "z"
+
     # Proximity index config
     scfg = cfg.get("sweep_cache", {})
     two_d = bool(scfg.get("two_d", True))
     cell_m = float(scfg.get("grid_size_m", 0.25))
     per_cell_cap = int(scfg.get("per_cell_cap", 64))
     neighbors_max = int(scfg.get("neighbors_max", 128))
-    pi_grid = GridSpec(cell_m=cell_m, use_3d=not two_d)
+    up_axis = str(scfg.get("up_axis", up_axis_default))
+    pi_grid = GridSpec(cell_m=cell_m, use_3d=not two_d, up_axis=up_axis)
     proximity_index = ProximityIndex(pi_grid, per_cell_cap=per_cell_cap, neighbors_max=neighbors_max)
     logger.info(f"Proximity index successfully initialized")
     wm = WorkingMemory(cfg, index=proximity_index)
@@ -88,6 +94,7 @@ def main():
         pitch_bins=int(cfg.get("sweep_cache", {}).get("pitch_bins", 5)),
         pitch_deg=float(cfg.get("sweep_cache", {}).get("pitch_deg", 60.0)),
         look_lru_keep=int(cfg.get("sweep_cache", {}).get("look_lru_keep", 8)),
+        up_axis=up_axis,
     )
     logger.info(f"Sweep cache successfully initialized")
 
@@ -109,9 +116,7 @@ def main():
     display_host = local_ips[0] if local_ips else "0.0.0.0"
 
     # ---------------- Receiver (ZMQ or WebSocket) ----------------
-    io_cfg = cfg.get("io", {})
     units_cfg = cfg.get("units", {})
-    receiver_type = str(io_cfg.get("receiver", "zeromq")).lower()
 
     # Will be set to FrameWindow or None depending on receiver
     frame_window_for_reset = None
@@ -125,7 +130,11 @@ def main():
             require_tracking_normal=bool(ws_cfg.get("require_tracking_normal", True)),
             keyframe_every_n=int(ws_cfg.get("keyframe_every_n", 30)),
             nonkf_min_interval_s=float(ws_cfg.get("nonkf_min_interval_s", 0.5)),
+            confidence_threshold=int(ws_cfg.get("confidence_threshold", 1)),
+            apply_camera_flip=bool(vis_cfg.get("apply_camera_flip", False)),
             on_keyframe=vis_server.handle_frame_packet if vis_server else None,
+            on_pose_corrections=vis_server.handle_kf_pose_update if vis_server else None,
+            on_pose_corrections_batch=vis_server.handle_pose_corrections_batch if vis_server else None,
         )
         ws_receiver.start()
         ws_port = int(ws_cfg.get("port", 8765))

--- a/rtsm/run.py
+++ b/rtsm/run.py
@@ -15,7 +15,7 @@ from rtsm.stores.sweep_cache import SweepCache
 from rtsm.io.ingest_queue import IngestQueue
 from rtsm.io.zeromq import ZeroMQSubscriber
 from rtsm.io.websocket import WebSocketReceiver
-from rtsm.utils.net import print_server_addresses
+from rtsm.utils.net import print_server_addresses, get_local_ipv4_addresses
 from rtsm.stores.sweep_policy import SweepPolicy
 from rtsm.api.server import create_app, start_server, ResetComponents
 
@@ -104,6 +104,10 @@ def main():
         )
         logger.info("Visualization server initialized")
 
+    # Resolve display IP (use real network IP instead of 0.0.0.0)
+    local_ips = get_local_ipv4_addresses()
+    display_host = local_ips[0] if local_ips else "0.0.0.0"
+
     # ---------------- Receiver (ZMQ or WebSocket) ----------------
     io_cfg = cfg.get("io", {})
     units_cfg = cfg.get("units", {})
@@ -121,11 +125,12 @@ def main():
             require_tracking_normal=bool(ws_cfg.get("require_tracking_normal", True)),
             keyframe_every_n=int(ws_cfg.get("keyframe_every_n", 30)),
             nonkf_min_interval_s=float(ws_cfg.get("nonkf_min_interval_s", 0.5)),
+            on_keyframe=vis_server.handle_frame_packet if vis_server else None,
         )
         ws_receiver.start()
         ws_port = int(ws_cfg.get("port", 8765))
         print_server_addresses(ws_port)
-        logger.info(f"WebSocket receiver started on port {ws_port}")
+        logger.info(f"WebSocket receiver started on ws://{display_host}:{ws_port}/stream")
 
     elif receiver_type == "zeromq":
         sub = ZeroMQSubscriber(
@@ -150,7 +155,8 @@ def main():
     # Start visualization server if enabled
     if vis_server:
         vis_server.start()
-        logger.info(f"Visualization WebSocket server started on port {vis_cfg.get('port', 8081)}")
+        vis_port_val = vis_cfg.get("port", 8081)
+        logger.info(f"Visualization server started on ws://{display_host}:{vis_port_val}/ws")
 
     pipe = Pipeline(
         cfg=cfg,
@@ -187,21 +193,21 @@ def main():
         reset_components=reset_components,
     )
     start_server(app, host=host, port=port)
-    logger.info(f"FastAPI server started on http://{host}:{port}")
+    logger.info(f"FastAPI server started on http://{display_host}:{port}")
 
     print("=" * 60)
     print("  RTSM is running! Waiting for data...")
     if receiver_type == "websocket":
         ws_port = int(io_cfg.get("websocket", {}).get("port", 8765))
-        print(f"  Receiver: WebSocket (ws://0.0.0.0:{ws_port}/stream)")
+        print(f"  Receiver: WebSocket (ws://{display_host}:{ws_port}/stream)")
     else:
         print(f"  Receiver: ZeroMQ")
         print(f"  Camera:  {io_cfg.get('camera_endpoint', 'tcp://127.0.0.1:5555')}")
         print(f"  RTABMap: {io_cfg.get('rtabmap_endpoint', 'tcp://127.0.0.1:6000')}")
-    print(f"  API:     http://{host}:{port}")
+    print(f"  API:     http://{display_host}:{port}")
     if vis_server:
         vis_port = vis_cfg.get("port", 8081)
-        print(f"  Vis WS:  ws://0.0.0.0:{vis_port}/ws")
+        print(f"  Vis WS:  ws://{display_host}:{vis_port}/ws")
     print("  Press Ctrl+C to stop")
     print("=" * 60)
 

--- a/rtsm/run.py
+++ b/rtsm/run.py
@@ -14,6 +14,8 @@ from rtsm.models.clip.vocab_classifier import ClipVocabClassifier
 from rtsm.stores.sweep_cache import SweepCache
 from rtsm.io.ingest_queue import IngestQueue
 from rtsm.io.zeromq import ZeroMQSubscriber
+from rtsm.io.websocket import WebSocketReceiver
+from rtsm.utils.net import print_server_addresses
 from rtsm.stores.sweep_policy import SweepPolicy
 from rtsm.api.server import create_app, start_server, ResetComponents
 
@@ -102,24 +104,48 @@ def main():
         )
         logger.info("Visualization server initialized")
 
-    # Start ZMQ subscriber in background (dual-socket: camera + RTABMap)
-    # Unit scales (incoming → meters). Defaults provided match typical RTABMap setup.
+    # ---------------- Receiver (ZMQ or WebSocket) ----------------
     io_cfg = cfg.get("io", {})
     units_cfg = cfg.get("units", {})
+    receiver_type = str(io_cfg.get("receiver", "zeromq")).lower()
 
-    sub = ZeroMQSubscriber(
-        camera_endpoint=io_cfg.get("camera_endpoint", "tcp://127.0.0.1:5555"),
-        rtabmap_endpoint=io_cfg.get("rtabmap_endpoint", "tcp://127.0.0.1:6000"),
-        ingest_queue=ingest_q,
-        depth_m_per_unit=float(units_cfg.get("depth_m_per_unit", 0.001)),
-        pose_m_per_unit=float(units_cfg.get("pose_m_per_unit", 1.0)),
-        # Visualization callbacks (None if disabled)
-        on_kf_packet=vis_server.handle_kf_packet if vis_server else None,
-        on_kf_pose_update=vis_server.handle_kf_pose_update if vis_server else None,
-    )
-    t = threading.Thread(target=sub.run_forever, daemon=True)
-    t.start()
-    logger.info(f"ZeroMQ dual-socket subscriber started (camera + RTABMap)")
+    # Will be set to FrameWindow or None depending on receiver
+    frame_window_for_reset = None
+
+    if receiver_type == "websocket":
+        ws_cfg = io_cfg.get("websocket", {})
+        ws_receiver = WebSocketReceiver(
+            ingest_queue=ingest_q,
+            host=str(ws_cfg.get("host", "0.0.0.0")),
+            port=int(ws_cfg.get("port", 8765)),
+            require_tracking_normal=bool(ws_cfg.get("require_tracking_normal", True)),
+            keyframe_every_n=int(ws_cfg.get("keyframe_every_n", 30)),
+            nonkf_min_interval_s=float(ws_cfg.get("nonkf_min_interval_s", 0.5)),
+        )
+        ws_receiver.start()
+        ws_port = int(ws_cfg.get("port", 8765))
+        print_server_addresses(ws_port)
+        logger.info(f"WebSocket receiver started on port {ws_port}")
+
+    elif receiver_type == "zeromq":
+        sub = ZeroMQSubscriber(
+            camera_endpoint=io_cfg.get("camera_endpoint", "tcp://127.0.0.1:5555"),
+            rtabmap_endpoint=io_cfg.get("rtabmap_endpoint", "tcp://127.0.0.1:6000"),
+            ingest_queue=ingest_q,
+            depth_m_per_unit=float(units_cfg.get("depth_m_per_unit", 0.001)),
+            pose_m_per_unit=float(units_cfg.get("pose_m_per_unit", 1.0)),
+            on_kf_packet=vis_server.handle_kf_packet if vis_server else None,
+            on_kf_pose_update=vis_server.handle_kf_pose_update if vis_server else None,
+        )
+        t = threading.Thread(target=sub.run_forever, daemon=True)
+        t.start()
+        logger.info(f"ZeroMQ dual-socket subscriber started (camera + RTABMap)")
+        frame_window_for_reset = sub.fw
+
+    else:
+        raise ValueError(
+            f"Unknown io.receiver: {receiver_type!r}. Choose 'zeromq' or 'websocket'."
+        )
 
     # Start visualization server if enabled
     if vis_server:
@@ -147,7 +173,7 @@ def main():
     # Components that can be reset without restarting RTSM
     reset_components = ResetComponents(
         sweep_cache=sweep_cache,
-        frame_window=sub.fw,  # FrameWindow created inside ZeroMQSubscriber
+        frame_window=frame_window_for_reset,  # FrameWindow (ZMQ) or None (WebSocket)
         vis_server=vis_server,
     )
 
@@ -165,8 +191,13 @@ def main():
 
     print("=" * 60)
     print("  RTSM is running! Waiting for data...")
-    print(f"  Camera:  {io_cfg.get('camera_endpoint', 'tcp://127.0.0.1:5555')}")
-    print(f"  RTABMap: {io_cfg.get('rtabmap_endpoint', 'tcp://127.0.0.1:6000')}")
+    if receiver_type == "websocket":
+        ws_port = int(io_cfg.get("websocket", {}).get("port", 8765))
+        print(f"  Receiver: WebSocket (ws://0.0.0.0:{ws_port}/stream)")
+    else:
+        print(f"  Receiver: ZeroMQ")
+        print(f"  Camera:  {io_cfg.get('camera_endpoint', 'tcp://127.0.0.1:5555')}")
+        print(f"  RTABMap: {io_cfg.get('rtabmap_endpoint', 'tcp://127.0.0.1:6000')}")
     print(f"  API:     http://{host}:{port}")
     if vis_server:
         vis_port = vis_cfg.get("port", 8081)

--- a/rtsm/stores/proximity_index.py
+++ b/rtsm/stores/proximity_index.py
@@ -33,19 +33,24 @@ class GridSpec:
     """
     World-space uniform grid.
     - cell_m: cell size in meters
-    - use_3d: True => (ix,iy,iz) keys; False => (ix,iy) keys
+    - use_3d: True => (ix,iy,iz) keys; False => 2D keys (drops vertical axis)
+    - up_axis: "z" (ROS/D435i) or "y" (ARKit) — controls which axis is vertical
     """
     cell_m: float = 0.25
     use_3d: bool = True
+    up_axis: str = "z"
 
     def cell(self, xyz_world: np.ndarray) -> Cell:
         x, y, z = float(xyz_world[0]), float(xyz_world[1]), float(xyz_world[2])
         ix = int(math.floor(x / self.cell_m))
         iy = int(math.floor(y / self.cell_m))
+        iz = int(math.floor(z / self.cell_m))
         if self.use_3d:
-            iz = int(math.floor(z / self.cell_m))
             return (ix, iy, iz)
-        return (ix, iy)
+        # 2D: keep the two horizontal axes, drop the vertical one
+        if self.up_axis == "y":
+            return (ix, iz)  # Y-up (ARKit): keep X, Z
+        return (ix, iy)      # Z-up (ROS): keep X, Y
 
     def neighbors(self, c: Cell, rings: int = 1) -> Iterable[Cell]:
         if rings <= 0:
@@ -58,10 +63,10 @@ class GridSpec:
                     for dz in range(-rings, rings + 1):
                         yield (ix + dx, iy + dy, iz + dz)
         else:
-            ix, iy = c  # type: ignore[misc]
-            for dx in range(-rings, rings + 1):
-                for dy in range(-rings, rings + 1):
-                    yield (ix + dx, iy + dy)
+            a, b = c  # type: ignore[misc]
+            for da in range(-rings, rings + 1):
+                for db in range(-rings, rings + 1):
+                    yield (a + da, b + db)
 
 # --------- proximity index (object membership by cell) ---------
 

--- a/rtsm/stores/sweep_cache.py
+++ b/rtsm/stores/sweep_cache.py
@@ -30,12 +30,15 @@ class SweepCache:
         pitch_bins: int = 5,
         pitch_deg: float = 60.0,
         look_lru_keep: int = 8,
+        up_axis: str = "z",
     ) -> None:
         # --- spatial grid ---
         self.grid = float(grid_size_m)
         self.cap = int(per_cell_cap)
         self.neighbors_max = int(neighbors_max)
         self.two_d = bool(two_d)
+        # World-frame up axis: "z" for ROS/D435i, "y" for ARKit
+        self.up_axis = up_axis.lower()
 
         # --- membership ---
         self.h: Dict[Cell, Set[str]] = defaultdict(set)   # cell -> {oid}
@@ -57,24 +60,31 @@ class SweepCache:
     def cell_from_xyz(self, xyz: np.ndarray) -> Cell:
         gx = int(math.floor(float(xyz[0]) / self.grid))
         gy = int(math.floor(float(xyz[1]) / self.grid))
+        gz = int(math.floor(float(xyz[2]) / self.grid))
         if self.two_d:
-            gz = 0
-        else:
-            gz = int(math.floor(float(xyz[2]) / self.grid))
+            # Drop the vertical axis: Z for Z-up (ROS/D435i), Y for Y-up (ARKit)
+            if self.up_axis == "y":
+                gy = 0
+            else:
+                gz = 0
         return (gx, gy, gz)
 
     def vbin_from_forward(self, fwd: np.ndarray) -> VBin:
-        # expects a (3,) vector; will normalize
+        # expects a (3,) world-frame forward vector; will normalize
         f = np.asarray(fwd, dtype=float)
         n = float(np.linalg.norm(f))
         if n == 0.0:
             # degenerate; put into bin 0, mid pitch
             return (0, self.pitch_bins // 2)
         f = f / n
-        # yaw in [-pi, pi]
-        yaw = math.atan2(float(f[1]), float(f[0]))
-        # pitch in [-pi/2, pi/2]
-        pitch = math.asin(max(-1.0, min(1.0, float(f[2]))))
+        if self.up_axis == "y":
+            # Y-up (ARKit): yaw = rotation around Y, pitch = elevation toward Y
+            yaw = math.atan2(float(f[0]), float(-f[2]))
+            pitch = math.asin(max(-1.0, min(1.0, float(f[1]))))
+        else:
+            # Z-up (ROS/D435i): yaw = rotation around Z, pitch = elevation toward Z
+            yaw = math.atan2(float(f[1]), float(f[0]))
+            pitch = math.asin(max(-1.0, min(1.0, float(f[2]))))
         # clamp pitch to useful range ±pitch_max
         pitch = max(-self.pitch_max, min(self.pitch_max, pitch))
         # normalize to [0,1]

--- a/rtsm/stores/working_memory.py
+++ b/rtsm/stores/working_memory.py
@@ -135,6 +135,9 @@ class ObjectState:
     # RGB crop gallery (JPEG-compressed bytes, most recent last)
     image_crops: List[bytes]
 
+    # Frame tracking for precise pose corrections
+    last_update_frame_id: Optional[str]
+
     # cache
     _dim: int
 
@@ -164,6 +167,8 @@ class WorkingMemory:
 
         self._map: Dict[str, ObjectState] = {}
         self._lock = threading.RLock()
+        # Reverse index: frame_id -> set of object IDs last updated on that frame
+        self._frame_to_objects: Dict[str, set] = {}
         # Min-heap of (deadline_mono, oid) for proto expiry (lazy re-schedule on matches)
         self._proto_heap: List[Tuple[float, str]] = []
 
@@ -228,7 +233,8 @@ class WorkingMemory:
                       label_topk: Optional[List[Tuple[str, float]]] = None,
                       view_dir_cam: Optional[np.ndarray] = None,
                       centroid_px: Optional[Tuple[float, float]] = None,
-                      crop: Optional[np.ndarray] = None) -> Optional[str]:
+                      crop: Optional[np.ndarray] = None,
+                      frame_id: Optional[str] = None) -> Optional[str]:
         """Spawn a new proto object. Index is updated here as well.
 
         Returns:
@@ -300,10 +306,14 @@ class WorkingMemory:
             last_upsert_emb=None,
             last_upsert_xyz=None,
             image_crops=image_crops,
+            last_update_frame_id=frame_id,
             _dim=D,
         )
         with self._lock:
             self._map[oid] = o
+            # Register in frame → objects reverse index
+            if frame_id is not None:
+                self._frame_to_objects.setdefault(frame_id, set()).add(oid)
             # schedule proto expiry (confirmed objects are never scheduled here)
             self._schedule_proto(oid, o)
         if self.index is not None:
@@ -407,6 +417,7 @@ class WorkingMemory:
         stab = min(1.0, o.stability + self.stab_k * gain * (1.0 - o.stability))
 
         # --- write back (under lock), and index move if needed ---
+        new_frame_id = getattr(obs, "frame_id", None)
         with self._lock:
             o.xyz_world = xyz_new.astype(np.float32)
             o.cov_world = o_cov.astype(np.float32)
@@ -416,6 +427,17 @@ class WorkingMemory:
             o.last_seen_mono = now_m
             o.last_seen_wall_utc = now_w
             o.last_seen_px = getattr(obs, "centroid_px", None)
+            # Update frame → objects reverse index
+            if new_frame_id is not None:
+                old_frame_id = o.last_update_frame_id
+                if old_frame_id is not None and old_frame_id != new_frame_id:
+                    old_set = self._frame_to_objects.get(old_frame_id)
+                    if old_set is not None:
+                        old_set.discard(oid)
+                        if not old_set:
+                            del self._frame_to_objects[old_frame_id]
+                self._frame_to_objects.setdefault(new_frame_id, set()).add(oid)
+                o.last_update_frame_id = new_frame_id
             # view_bins, label_scores, label_primary already updated on o
             # If still proto, push a fresh deadline (lazy heap pattern tolerates duplicates)
             if not o.confirmed:
@@ -568,6 +590,13 @@ class WorkingMemory:
                     # deadline extended; push a fresh entry (lazy heap pattern)
                     heapq.heappush(self._proto_heap, (true_deadline, oid))
                     continue
+                # Clean up frame → objects reverse index
+                if o.last_update_frame_id is not None:
+                    fset = self._frame_to_objects.get(o.last_update_frame_id)
+                    if fset is not None:
+                        fset.discard(oid)
+                        if not fset:
+                            del self._frame_to_objects[o.last_update_frame_id]
                 # really expired
                 removed.append(oid)
                 del self._map[oid]
@@ -581,6 +610,84 @@ class WorkingMemory:
         """Push a (deadline, oid) for a proto object into the heap. Lock must be held."""
         deadline = o.last_seen_mono + self.proto_ttl_s
         heapq.heappush(self._proto_heap, (deadline, oid))
+
+    # ---------- pose corrections (loop closure) ----------
+
+    def apply_pose_corrections(
+        self,
+        frame_corrections: Dict[str, Tuple[np.ndarray, np.ndarray, np.ndarray]],
+    ) -> int:
+        """Apply retroactive pose corrections from SLAM loop closure.
+
+        Uses the frame_id → object_ids reverse index for precise correction:
+        objects linked to a corrected frame get that frame's exact delta.
+        Objects not linked to any corrected frame fall back to the delta
+        from the spatially nearest corrected camera position.
+
+        Args:
+            frame_corrections: dict mapping frame_id to
+                (old_cam_pos_3, delta_R_3x3, delta_t_3).
+                delta transforms a world point: p_new = delta_R @ p_old + delta_t
+
+        Returns:
+            Number of objects corrected.
+        """
+        if not frame_corrections:
+            return 0
+
+        corrected_oids: set = set()
+        corrected = 0
+
+        with self._lock:
+            # Phase 1: Direct frame_id → object lookup
+            for frame_id, (_, delta_R, delta_t) in frame_corrections.items():
+                linked_oids = self._frame_to_objects.get(frame_id, set())
+                for oid in linked_oids:
+                    o = self._map.get(oid)
+                    if o is None:
+                        continue
+                    old_xyz = o.xyz_world.copy()
+                    new_xyz = (delta_R @ old_xyz + delta_t).astype(np.float32)
+                    o.xyz_world = new_xyz
+                    corrected += 1
+                    corrected_oids.add(oid)
+                    if self.index is not None:
+                        old_cell = self.index.grid.cell(old_xyz)
+                        new_cell = self.index.grid.cell(new_xyz)
+                        if old_cell != new_cell:
+                            self.index.update(oid, old_xyz, new_xyz, wm_lookup=self.lookup_min)
+
+            # Phase 2: Spatial fallback for objects not linked to any corrected frame
+            uncorrected = [o for o in self._map.values() if o.id not in corrected_oids]
+            if uncorrected:
+                cam_positions = np.array(
+                    [v[0] for v in frame_corrections.values()], dtype=np.float32
+                )
+                deltas_list = list(frame_corrections.values())
+                for o in uncorrected:
+                    old_xyz = o.xyz_world.copy()
+                    diffs = cam_positions - old_xyz[None, :]
+                    dists = np.linalg.norm(diffs, axis=1)
+                    nearest_idx = int(np.argmin(dists))
+                    _, delta_R, delta_t = deltas_list[nearest_idx]
+                    new_xyz = (delta_R @ old_xyz + delta_t).astype(np.float32)
+                    o.xyz_world = new_xyz
+                    corrected += 1
+                    if self.index is not None:
+                        old_cell = self.index.grid.cell(old_xyz)
+                        new_cell = self.index.grid.cell(new_xyz)
+                        if old_cell != new_cell:
+                            self.index.update(o.id, old_xyz, new_xyz, wm_lookup=self.lookup_min)
+
+        if corrected > 0:
+            direct = len(corrected_oids)
+            fallback = corrected - direct
+            logger.info(
+                f"[WM] Applied pose corrections to {corrected} objects "
+                f"({direct} direct, {fallback} fallback) "
+                f"from {len(frame_corrections)} frame deltas"
+            )
+        return corrected
 
     # ---------- utilities ----------
 
@@ -613,9 +720,10 @@ class WorkingMemory:
             # Clear object map
             self._map.clear()
 
-            # Clear scheduling heaps
+            # Clear scheduling heaps and reverse index
             self._proto_heap.clear()
             self._ltm_heap.clear()
+            self._frame_to_objects.clear()
 
             # Reset counters
             self._upsert_count_total = 0

--- a/rtsm/utils/mask_staging.py
+++ b/rtsm/utils/mask_staging.py
@@ -18,6 +18,23 @@ import numpy as np
 import torch
 import cv2
 
+# ---------- depth coordinate mapping ----------
+
+def _depth_coords(
+    ys: np.ndarray, xs: np.ndarray,
+    depth_shape: Tuple[int, int], mask_shape: Tuple[int, int],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Map mask-space (y, x) to depth-space.  No-op when shapes match."""
+    dh, dw = depth_shape
+    mh, mw = mask_shape
+    if dh == mh and dw == mw:
+        return ys, xs
+    sy = dh / mh
+    sx = dw / mw
+    dy = np.clip((ys * sy).astype(int), 0, dh - 1)
+    dx = np.clip((xs * sx).astype(int), 0, dw - 1)
+    return dy, dx
+
 # ---------- erosion helper ----------
 
 def _erode_mask(mask: torch.Tensor, kernel_size: int = 3) -> torch.Tensor:
@@ -65,7 +82,12 @@ def _depth_quantiles(mask: torch.Tensor, depth_m: np.ndarray, erode_px: int = 0)
     if erode_px > 0:
         mask = _erode_mask(mask, kernel_size=erode_px * 2 + 1)
     m = mask.contiguous().numpy()
-    z = depth_m[m]
+    ys, xs = np.where(m)
+    if ys.size == 0:
+        return 0.0, None, None
+    # Map mask-space coords to depth-space (no-op when resolutions match)
+    dy, dx = _depth_coords(ys, xs, depth_m.shape, m.shape)
+    z = depth_m[dy, dx]
     good = np.isfinite(z) & (z > 0.0)
     if not good.any(): return 0.0, None, None  # valid_pct, p50, spread
     zg = z[good]
@@ -86,6 +108,7 @@ def _centroid_cam(mask: torch.Tensor, depth_m: np.ndarray,
     """Compute 3D centroid in camera frame from mask and depth.
 
     Uses fast vectorized single-pixel depth sampling.
+    Handles depth at different resolution than mask (coordinate scaling).
     """
     # Optionally erode mask to avoid edge depth artifacts
     if erode_px > 0:
@@ -96,11 +119,13 @@ def _centroid_cam(mask: torch.Tensor, depth_m: np.ndarray,
     ys = ys[::stride]; xs = xs[::stride]
     if ys.size == 0: return None
 
-    # Fast vectorized single-pixel depth sampling
-    z = depth_m[ys, xs].astype(np.float32)
+    # Map to depth-space for lookup (no-op when resolutions match)
+    dy, dx = _depth_coords(ys, xs, depth_m.shape, m.shape)
+    z = depth_m[dy, dx].astype(np.float32)
 
     good = np.isfinite(z) & (z > 0.0)
     if not good.any(): return None
+    # Keep RGB-space coords for back-projection (intrinsics are RGB-space)
     ys = ys[good].astype(np.float32)
     xs = xs[good].astype(np.float32)
     z  = z[good]
@@ -131,10 +156,13 @@ def _sample_cam_points_from_mask(
     xs = xs[::stride]
     if ys.size == 0:
         return None
-    z = depth_m[ys, xs].astype(np.float32)
+    # Map to depth-space for lookup (no-op when resolutions match)
+    dy, dx = _depth_coords(ys, xs, depth_m.shape, m.shape)
+    z = depth_m[dy, dx].astype(np.float32)
     good = np.isfinite(z) & (z > 0.0)
     if not good.any():
         return None
+    # Keep RGB-space coords for back-projection (intrinsics are RGB-space)
     ys = ys[good].astype(np.float32)
     xs = xs[good].astype(np.float32)
     z  = z[good]

--- a/rtsm/utils/net.py
+++ b/rtsm/utils/net.py
@@ -1,0 +1,59 @@
+"""Network utility functions for RTSM."""
+
+from __future__ import annotations
+import socket
+import logging
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+def get_local_ipv4_addresses() -> List[str]:
+    """
+    Return list of non-loopback IPv4 addresses for this machine.
+    Uses stdlib only — no external dependencies.
+    """
+    addrs: List[str] = []
+
+    # Preferred method: UDP connect trick to find outbound IP
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            preferred = s.getsockname()[0]
+            if preferred and preferred != "0.0.0.0":
+                addrs.append(preferred)
+    except Exception:
+        pass
+
+    # Fallback: getaddrinfo on hostname
+    if not addrs:
+        try:
+            hostname = socket.gethostname()
+            for info in socket.getaddrinfo(hostname, None, socket.AF_INET):
+                addr = info[4][0]
+                if addr and not addr.startswith("127."):
+                    if addr not in addrs:
+                        addrs.append(addr)
+        except Exception:
+            pass
+
+    return addrs
+
+
+def print_server_addresses(port: int, protocol: str = "ws") -> None:
+    """
+    Print reachable server addresses for the given port.
+    Called at startup so user can configure the iOS client.
+    """
+    addrs = get_local_ipv4_addresses()
+    if addrs:
+        logger.info(f"WebSocket receiver listening on port {port}")
+        for addr in addrs:
+            url = f"{protocol}://{addr}:{port}/stream"
+            logger.info(f"  -> {url}")
+            print(f"  Calabi Lens: {url}")
+    else:
+        logger.warning(
+            "Could not detect local IP address; "
+            "client must use hostname or IP manually"
+        )

--- a/rtsm/utils/transforms.py
+++ b/rtsm/utils/transforms.py
@@ -104,3 +104,48 @@ def euler_to_rotation_matrix(roll: float, pitch: float, yaw: float) -> NDArray[n
         [sy * cp, sy * sp * sr + cy * cr, sy * sp * cr - cy * sr],
         [-sp,     cp * sr,                cp * cr               ]
     ], dtype=np.float32)
+
+
+def rotmat_to_quat_xyzw(R: NDArray[np.float32]) -> NDArray[np.float32]:
+    """
+    Convert a 3x3 rotation matrix to quaternion [x, y, z, w].
+
+    Uses Shepperd's method for numerical stability (avoids division
+    by near-zero when trace is small).
+
+    Args:
+        R: 3x3 rotation matrix (SO(3))
+
+    Returns:
+        Quaternion as numpy array [x, y, z, w] (Hamilton convention)
+    """
+    trace = float(R[0, 0] + R[1, 1] + R[2, 2])
+
+    if trace > 0:
+        s = 0.5 / math.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (R[2, 1] - R[1, 2]) * s
+        y = (R[0, 2] - R[2, 0]) * s
+        z = (R[1, 0] - R[0, 1]) * s
+    elif R[0, 0] > R[1, 1] and R[0, 0] > R[2, 2]:
+        s = 2.0 * math.sqrt(1.0 + float(R[0, 0]) - float(R[1, 1]) - float(R[2, 2]))
+        w = (R[2, 1] - R[1, 2]) / s
+        x = 0.25 * s
+        y = (R[0, 1] + R[1, 0]) / s
+        z = (R[0, 2] + R[2, 0]) / s
+    elif R[1, 1] > R[2, 2]:
+        s = 2.0 * math.sqrt(1.0 + float(R[1, 1]) - float(R[0, 0]) - float(R[2, 2]))
+        w = (R[0, 2] - R[2, 0]) / s
+        x = (R[0, 1] + R[1, 0]) / s
+        y = 0.25 * s
+        z = (R[1, 2] + R[2, 1]) / s
+    else:
+        s = 2.0 * math.sqrt(1.0 + float(R[2, 2]) - float(R[0, 0]) - float(R[1, 1]))
+        w = (R[1, 0] - R[0, 1]) / s
+        x = (R[0, 2] + R[2, 0]) / s
+        y = (R[1, 2] + R[2, 1]) / s
+        z = 0.25 * s
+
+    q = np.array([x, y, z, w], dtype=np.float32)
+    q /= float(np.linalg.norm(q) + 1e-12)
+    return q

--- a/rtsm/utils/transforms.py
+++ b/rtsm/utils/transforms.py
@@ -6,7 +6,9 @@ Provides conversions between rotation representations (Euler angles, quaternions
 
 from __future__ import annotations
 import math
+from typing import Optional
 import numpy as np
+import torch
 from numpy.typing import NDArray
 
 
@@ -149,3 +151,37 @@ def rotmat_to_quat_xyzw(R: NDArray[np.float32]) -> NDArray[np.float32]:
     q = np.array([x, y, z, w], dtype=np.float32)
     q /= float(np.linalg.norm(q) + 1e-12)
     return q
+
+
+# ─────────────── Image orientation utilities ───────────────
+
+_ORIENTATION_TO_K = {
+    "portrait": 1,            # 90° CCW to upright
+    "landscapeLeft": 2,       # 180°
+    "portraitUpsideDown": 3,  # 270° CCW
+}
+
+
+def orientation_to_rot90_k(device_orientation: Optional[str]) -> int:
+    """Map device orientation string to np.rot90 k value.
+
+    Returns 0 (no rotation) for landscapeRight, unknown, or None.
+    """
+    return _ORIENTATION_TO_K.get(device_orientation, 0)
+
+
+def rotate_image(img: NDArray[np.uint8], k: int) -> NDArray[np.uint8]:
+    """Rotate image by k*90° CCW. k=0 returns unchanged."""
+    if k == 0:
+        return img
+    return np.rot90(img, k=k).copy()
+
+
+def unrotate_masks(masks: torch.Tensor, k: int) -> torch.Tensor:
+    """Reverse a k*90°-CCW rotation on masks [N,H,W].
+
+    Applies (4-k)*90° CCW = k*90° CW to bring masks back to sensor space.
+    """
+    if k == 0:
+        return masks
+    return torch.rot90(masks, k=4 - k, dims=[1, 2]).contiguous()

--- a/rtsm/visualization/server.py
+++ b/rtsm/visualization/server.py
@@ -20,6 +20,7 @@ from typing import Optional, Callable, Any, Dict, List
 from contextlib import asynccontextmanager
 
 import numpy as np
+import cv2
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
@@ -393,6 +394,73 @@ class VisualizationServer:
                     self._loop
                 )
             logger.debug(f"[visualization] Pose updated for KF {mesh_id} (BA/LC)")
+
+    def handle_frame_packet(self, pkt) -> None:
+        """
+        Handle a decoded FramePacket from the WebSocket receiver.
+
+        Generates a point cloud from the already-decoded RGB + depth + pose
+        and broadcasts it to visualization clients. Called from the WebSocket
+        receiver thread for keyframes only.
+        """
+        try:
+            if pkt.depth_m is None or pkt.pose is None or pkt.intr is None:
+                return
+
+            mesh_id = f"ws_{pkt.time.seq}"
+
+            # Build 3x3 intrinsics matrix
+            K = np.array([
+                [pkt.intr.fx, 0, pkt.intr.cx],
+                [0, pkt.intr.fy, pkt.intr.cy],
+                [0, 0, 1],
+            ], dtype=np.float32)
+
+            rgb = pkt.rgb
+            depth_m = pkt.depth_m
+
+            # Resize depth to RGB resolution if mismatched (ARKit LiDAR 256x192 vs RGB 640x480)
+            rgb_h, rgb_w = rgb.shape[:2]
+            dep_h, dep_w = depth_m.shape[:2]
+            if dep_h != rgb_h or dep_w != rgb_w:
+                depth_m = cv2.resize(depth_m, (rgb_w, rgb_h), interpolation=cv2.INTER_NEAREST)
+
+            # Filter and back-project
+            depth_filtered = self.processor.filter_depth(depth_m)
+            positions, colors = self.processor.backproject(depth_filtered, rgb, K)
+
+            if positions.shape[0] == 0:
+                logger.debug(f"[visualization] Frame {mesh_id} produced 0 points, skipping")
+                return
+
+            # Build 4x4 T_wc pose
+            pose = pkt.pose.T_wc()
+
+            # Debug: log pose translation
+            t_vis = pose[:3, 3]
+            logger.debug(f"[visualization] WS frame {mesh_id} pose: [{t_vis[0]:.3f}, {t_vis[1]:.3f}, {t_vis[2]:.3f}]")
+
+            # Register and broadcast
+            self.registry.register(
+                mesh_id=mesh_id,
+                timestamp_ns=int(pkt.time.t_sensor_ns or 0),
+                positions=positions,
+                colors=colors,
+                pose=pose,
+                map_id="websocket",
+            )
+
+            if self._loop and self._running:
+                asyncio.run_coroutine_threadsafe(
+                    self.broadcaster.send_mesh_create(mesh_id, positions, colors, pose),
+                    self._loop,
+                )
+
+            stats = self.registry.stats()
+            logger.debug(f"[visualization] WS {mesh_id}: {positions.shape[0]:,} pts | Total: {stats['keyframes']} KFs")
+
+        except Exception as e:
+            logger.error(f"[visualization] Error processing frame packet: {e}")
 
     def _run_server(self) -> None:
         """Run uvicorn server in background thread."""

--- a/rtsm/visualization/server.py
+++ b/rtsm/visualization/server.py
@@ -29,6 +29,13 @@ from rtsm.visualization.processor import PointCloudProcessor, ProcessorConfig
 from rtsm.visualization.registry import KeyframeRegistry
 from rtsm.visualization.broadcaster import WSBroadcaster
 
+# TSDF fusion (optional � requires open3d)
+try:
+    from rtsm.visualization.tsdf_integrator import TSDFIntegrator, TSDFConfig
+    _HAS_TSDF = True
+except ImportError:
+    _HAS_TSDF = False
+
 logger = logging.getLogger(__name__)
 
 
@@ -145,10 +152,58 @@ class VisualizationServer:
         self._push_interval_ms = vis_cfg.get("objects", {}).get("push_interval_ms", 200)
         self._include_proto = vis_cfg.get("objects", {}).get("include_proto", True)
 
+        # Depth config for visualization
+        depth_cfg = vis_cfg.get("depth", {})
+        proc_depth_min = float(depth_cfg.get("min_m", 0.1))
+        proc_depth_max = float(depth_cfg.get("max_m", 3.5))
+
         # Components
-        self.processor = PointCloudProcessor(ProcessorConfig())
+        self.processor = PointCloudProcessor(ProcessorConfig(
+            depth_min_m=proc_depth_min,
+            depth_max_m=proc_depth_max,
+        ))
         self.registry = KeyframeRegistry()
         self.broadcaster = WSBroadcaster()
+
+        # TSDF volumetric fusion (optional)
+        self.tsdf = None
+        tsdf_cfg = vis_cfg.get("tsdf", {})
+        if tsdf_cfg.get("enable", False) and _HAS_TSDF:
+            try:
+                self.tsdf = TSDFIntegrator(
+                    TSDFConfig(
+                        voxel_size=float(tsdf_cfg.get("voxel_size", 0.01)),
+                        sdf_trunc=float(tsdf_cfg.get("sdf_trunc", 0.04)),
+                        max_depth_m=float(tsdf_cfg.get("max_depth_m", proc_depth_max)),
+                        min_depth_m=proc_depth_min,
+                        extract_every_n=int(tsdf_cfg.get("extract_every_n", 30)),
+                        extract_interval_s=float(tsdf_cfg.get("extract_interval_s", 2.0)),
+                        frame_buffer_size=int(tsdf_cfg.get("frame_buffer_size", 200)),
+                        correction_reset_threshold_m=float(
+                            tsdf_cfg.get("correction_reset_threshold_m", 0.05)
+                        ),
+                    ),
+                )
+                logger.info("[visualization] TSDF fusion enabled")
+            except RuntimeError as e:
+                logger.warning(f"[visualization] TSDF unavailable: {e}")
+        elif tsdf_cfg.get("enable", False) and not _HAS_TSDF:
+            logger.warning(
+                "[visualization] TSDF enabled in config but open3d not installed"
+            )
+
+        # Max resolution for TSDF/visualization integration
+        # (LiDAR depth is 256x192; upscaling to 1920x1440 RGB wastes compute)
+        self._integration_max_width = int(tsdf_cfg.get("integration_max_width", 640))
+
+        # Pose history for retroactive WM correction (frame_id -> T_wc 4x4)
+        self._pose_history: Dict[str, np.ndarray] = {}
+        self._pose_history_max = int(
+            tsdf_cfg.get("frame_buffer_size", 200) * 2
+        )  # keep slightly more history than TSDF buffer
+        self._correct_wm = bool(
+            cfg.get("slam", {}).get("correct_working_memory", True)
+        )
 
         # Server state
         self._app: Optional[FastAPI] = None
@@ -196,8 +251,19 @@ class VisualizationServer:
             await websocket.accept()
             await self.broadcaster.connect(websocket)
 
-            # Sync existing keyframes to new client
+            # Sync existing keyframes/TSDF mesh to new client
             synced = await self.broadcaster.sync_new_client(websocket, self.registry)
+            # Also send latest TSDF mesh if available
+            if self.tsdf is not None:
+                latest = self.tsdf.get_latest_mesh()
+                if latest is not None:
+                    positions, colors = latest
+                    identity = np.eye(4, dtype=np.float32)
+                    data = self.broadcaster._pack_mesh_create(
+                        "tsdf_fused", positions, colors, identity
+                    )
+                    await self.broadcaster._send_bytes_to(websocket, data)
+                    synced += 1
             logger.debug(f"[visualization] New client synced with {synced} keyframes")
 
             try:
@@ -219,10 +285,13 @@ class VisualizationServer:
 
         @app.get("/stats")
         async def stats():
-            return {
+            result = {
                 **self.registry.stats(),
-                "clients": self.broadcaster.client_count
+                "clients": self.broadcaster.client_count,
             }
+            if self.tsdf is not None:
+                result.update(self.tsdf.stats())
+            return result
 
         return app
 
@@ -232,8 +301,10 @@ class VisualizationServer:
 
         if cmd == "clear":
             count = self.registry.clear()
+            if self.tsdf is not None:
+                self.tsdf.reset()
             await self.broadcaster._broadcast_json({"type": "clear"})
-            logger.info(f"[visualization] Cleared {count} keyframes")
+            logger.info(f"[visualization] Cleared {count} keyframes (TSDF reset: {self.tsdf is not None})")
 
         elif cmd == "stats":
             stats = self.registry.stats()
@@ -383,7 +454,7 @@ class VisualizationServer:
         """
         Handle pose correction from bundle adjustment or loop closure.
 
-        Called from ZMQ subscriber thread.
+        Called from ZMQ subscriber thread or WebSocket receiver.
         """
         mesh_id = kf_id
 
@@ -395,6 +466,39 @@ class VisualizationServer:
                 )
             logger.debug(f"[visualization] Pose updated for KF {mesh_id} (BA/LC)")
 
+    def handle_pose_corrections_batch(self, corrections: dict) -> None:
+        """
+        Handle a batch of pose corrections from loop closure.
+
+        When TSDF is enabled, applies corrections to the TSDF volume.
+        Otherwise delegates per-correction to handle_kf_pose_update.
+        Also retroactively corrects WorkingMemory object positions.
+        """
+        if not corrections:
+            return
+
+        # ---- Correct WorkingMemory objects ----
+        if self._correct_wm and self.wm is not None:
+            self._apply_wm_pose_corrections(corrections)
+
+        # ---- Correct TSDF / per-frame meshes ----
+        if self.tsdf is not None:
+            was_reset = self.tsdf.handle_pose_corrections(corrections)
+            if was_reset:
+                threading.Thread(
+                    target=self._extract_and_broadcast_tsdf,
+                    daemon=True,
+                    name="tsdf-reintegrate-extract",
+                ).start()
+        else:
+            for kf_id, corr_pose in corrections.items():
+                self.handle_kf_pose_update(kf_id, corr_pose)
+
+        # Update pose history with corrected poses
+        for kf_id, new_pose in corrections.items():
+            if isinstance(new_pose, np.ndarray):
+                self._pose_history[kf_id] = new_pose.copy()
+
     def handle_frame_packet(self, pkt) -> None:
         """
         Handle a decoded FramePacket from the WebSocket receiver.
@@ -402,6 +506,9 @@ class VisualizationServer:
         Generates a point cloud from the already-decoded RGB + depth + pose
         and broadcasts it to visualization clients. Called from the WebSocket
         receiver thread for keyframes only.
+
+        When TSDF is enabled, integrates frames into the TSDF volume and
+        periodically extracts a fused point cloud.
         """
         try:
             if pkt.depth_m is None or pkt.pose is None or pkt.intr is None:
@@ -419,12 +526,80 @@ class VisualizationServer:
             rgb = pkt.rgb
             depth_m = pkt.depth_m
 
-            # Resize depth to RGB resolution if mismatched (ARKit LiDAR 256x192 vs RGB 640x480)
+            # Apply additional confidence filtering for visualization quality
+            # (pipeline already filters at ingestion, but vis may benefit from stricter threshold)
+            confidence = getattr(pkt, 'confidence', None)
+            if confidence is not None and depth_m is not None:
+                dep_h, dep_w = depth_m.shape[:2]
+                conf_h, conf_w = confidence.shape[:2]
+                if conf_h != dep_h or conf_w != dep_w:
+                    confidence = cv2.resize(
+                        confidence, (dep_w, dep_h),
+                        interpolation=cv2.INTER_NEAREST
+                    )
+                # For visualization/TSDF, only use high-confidence depth (level 2)
+                depth_m = depth_m.copy()
+                depth_m[confidence < 2] = np.nan
+
+            # Downsample to target resolution for efficiency
+            # (LiDAR depth is 256x192; upscaling to 1920x1440 RGB wastes compute)
             rgb_h, rgb_w = rgb.shape[:2]
+            max_w = self._integration_max_width
+            if rgb_w > max_w:
+                scale = max_w / rgb_w
+                target_h = int(rgb_h * scale)
+                rgb = cv2.resize(rgb, (max_w, target_h), interpolation=cv2.INTER_AREA)
+                K = K.copy()
+                K[0, 0] *= scale
+                K[1, 1] *= scale
+                K[0, 2] *= scale
+                K[1, 2] *= scale
+                rgb_h, rgb_w = target_h, max_w
+
+            # Resize depth to match (downsampled) RGB if mismatched
             dep_h, dep_w = depth_m.shape[:2]
             if dep_h != rgb_h or dep_w != rgb_w:
                 depth_m = cv2.resize(depth_m, (rgb_w, rgb_h), interpolation=cv2.INTER_NEAREST)
 
+            # Build 4x4 T_wc pose
+            pose = pkt.pose.T_wc()
+
+            # Store original pose for retroactive WM correction
+            self._pose_history[mesh_id] = pose.copy()
+            if len(self._pose_history) > self._pose_history_max:
+                # Evict oldest entries (dict preserves insertion order in Python 3.7+)
+                excess = len(self._pose_history) - self._pose_history_max
+                for key in list(self._pose_history.keys())[:excess]:
+                    del self._pose_history[key]
+
+            # Note: ARKit→OpenCV camera flip is applied at ingestion
+            # (WebSocketReceiver) so pose is already in OpenCV convention.
+
+            # ---- TSDF path ----
+            if self.tsdf is not None:
+                # Convert BGR -> RGB (pkt.rgb is BGR from OpenCV decode)
+                rgb_for_tsdf = rgb[:, :, ::-1].copy()
+
+                should_extract = self.tsdf.integrate(
+                    frame_id=mesh_id,
+                    rgb=rgb_for_tsdf,
+                    depth_m=depth_m,
+                    K=K,
+                    pose_T_wc=pose,
+                    width=rgb_w,
+                    height=rgb_h,
+                    timestamp_ns=int(pkt.time.t_sensor_ns or 0),
+                )
+
+                if should_extract and self._loop and self._running:
+                    threading.Thread(
+                        target=self._extract_and_broadcast_tsdf,
+                        daemon=True,
+                        name="tsdf-extract",
+                    ).start()
+                return  # Skip per-frame mesh path when TSDF is active
+
+            # ---- Legacy per-frame path ----
             # Filter and back-project
             depth_filtered = self.processor.filter_depth(depth_m)
             positions, colors = self.processor.backproject(depth_filtered, rgb, K)
@@ -432,9 +607,6 @@ class VisualizationServer:
             if positions.shape[0] == 0:
                 logger.debug(f"[visualization] Frame {mesh_id} produced 0 points, skipping")
                 return
-
-            # Build 4x4 T_wc pose
-            pose = pkt.pose.T_wc()
 
             # Debug: log pose translation
             t_vis = pose[:3, 3]
@@ -461,6 +633,78 @@ class VisualizationServer:
 
         except Exception as e:
             logger.error(f"[visualization] Error processing frame packet: {e}")
+
+    def _apply_wm_pose_corrections(self, corrections: dict) -> None:
+        """
+        Compute per-frame rigid correction deltas and apply them to WM objects.
+
+        For each corrected frame where we have the original pose in history,
+        computes delta_R, delta_t such that:  p_new = delta_R @ p_old + delta_t
+
+        Passes a frame_id-keyed dict to wm.apply_pose_corrections so that
+        objects are corrected using the exact delta from the frame that last
+        updated them, with spatial proximity fallback for unlinked objects.
+        """
+        # Build frame_id -> (old_cam_pos, delta_R, delta_t)
+        frame_corrections: Dict[str, tuple] = {}
+
+        for kf_id, new_pose in corrections.items():
+            old_pose = self._pose_history.get(kf_id)
+            if old_pose is None:
+                continue
+            if not isinstance(new_pose, np.ndarray):
+                continue
+
+            old_pose = old_pose.astype(np.float64)
+            new_pose_f64 = new_pose.astype(np.float64)
+
+            # delta_T = T_wc_new @ inv(T_wc_old)
+            # p_world_new = delta_T @ p_world_old  (homogeneous)
+            try:
+                delta_T = new_pose_f64 @ np.linalg.inv(old_pose)
+            except np.linalg.LinAlgError:
+                continue
+
+            delta_R = delta_T[:3, :3].astype(np.float32)
+            delta_t = delta_T[:3, 3].astype(np.float32)
+            old_cam_pos = old_pose[:3, 3].astype(np.float32)
+
+            frame_corrections[kf_id] = (old_cam_pos, delta_R, delta_t)
+
+        if frame_corrections:
+            try:
+                n = self.wm.apply_pose_corrections(frame_corrections)
+                logger.info(
+                    f"[visualization] WM pose correction: {n} objects updated "
+                    f"from {len(frame_corrections)} frame deltas"
+                )
+            except Exception as e:
+                logger.error(f"[visualization] WM pose correction failed: {e}")
+
+    def _extract_and_broadcast_tsdf(self) -> None:
+        """Extract fused point cloud from TSDF and broadcast to clients."""
+        try:
+            positions, colors = self.tsdf.extract_point_cloud()
+            if positions.shape[0] == 0:
+                return
+
+            # TSDF points are already in world frame; use identity pose
+            identity = np.eye(4, dtype=np.float32)
+
+            if self._loop and self._running:
+                asyncio.run_coroutine_threadsafe(
+                    self.broadcaster.send_mesh_create(
+                        "tsdf_fused", positions, colors, identity
+                    ),
+                    self._loop,
+                )
+
+            logger.debug(
+                f"[visualization] TSDF extracted {positions.shape[0]:,} pts "
+                f"(v{self.tsdf.mesh_version})"
+            )
+        except Exception as e:
+            logger.error(f"[visualization] TSDF extraction error: {e}")
 
     def _run_server(self) -> None:
         """Run uvicorn server in background thread."""

--- a/rtsm/visualization/tsdf_integrator.py
+++ b/rtsm/visualization/tsdf_integrator.py
@@ -1,0 +1,329 @@
+"""
+TSDF Volumetric Fusion for RTSM Visualization.
+
+Wraps Open3D's ScalableTSDFVolume to fuse RGB-D frames with known poses
+into a consistent 3D reconstruction. Replaces per-frame point cloud
+accumulation which suffers from visible drift layering.
+"""
+
+import threading
+import time
+import logging
+from collections import deque
+from dataclasses import dataclass
+from typing import Optional, Tuple, Deque, Dict
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+try:
+    import open3d as o3d
+except ImportError:
+    o3d = None
+    logger.warning(
+        "[tsdf] open3d not installed — TSDF fusion unavailable. "
+        "Install with: pip install open3d"
+    )
+
+
+@dataclass
+class TSDFConfig:
+    """Configuration for TSDF integration."""
+    voxel_size: float = 0.01
+    sdf_trunc: float = 0.04
+    max_depth_m: float = 3.5
+    min_depth_m: float = 0.1
+    extract_every_n: int = 30
+    extract_interval_s: float = 2.0
+    frame_buffer_size: int = 200
+    correction_reset_threshold_m: float = 0.05
+
+
+@dataclass
+class BufferedFrame:
+    """A frame stored in the ring buffer for potential re-integration."""
+    frame_id: str
+    rgb: np.ndarray           # (H, W, 3) uint8 RGB
+    depth_m: np.ndarray       # (H, W) float32 meters
+    intrinsic: "o3d.camera.PinholeCameraIntrinsic"
+    pose: np.ndarray          # (4, 4) float64 T_wc
+    timestamp_ns: int
+
+
+class TSDFIntegrator:
+    """
+    Thread-safe TSDF volume integrator using Open3D ScalableTSDFVolume.
+
+    Integrates incoming RGB-D frames with camera poses and periodically
+    extracts a fused point cloud for visualization.
+    """
+
+    def __init__(self, config: Optional[TSDFConfig] = None):
+        if o3d is None:
+            raise RuntimeError(
+                "open3d is required for TSDF fusion. "
+                "Install with: pip install open3d"
+            )
+
+        self.cfg = config or TSDFConfig()
+        self._lock = threading.Lock()
+
+        # Create TSDF volume
+        self._volume = self._create_volume()
+
+        # Frame counter and timing for extraction triggers
+        self._frames_since_extract: int = 0
+        self._last_extract_time: float = 0.0
+        self._total_integrated: int = 0
+
+        # Ring buffer of raw frames for re-integration
+        self._frame_buffer: Deque[BufferedFrame] = deque(
+            maxlen=self.cfg.frame_buffer_size
+        )
+
+        # Latest extracted mesh data (positions + colors)
+        self._latest_positions: Optional[np.ndarray] = None
+        self._latest_colors: Optional[np.ndarray] = None
+        self._mesh_version: int = 0
+
+        logger.info(
+            f"[tsdf] Initialized: voxel={self.cfg.voxel_size}m, "
+            f"trunc={self.cfg.sdf_trunc}m, "
+            f"depth=[{self.cfg.min_depth_m}, {self.cfg.max_depth_m}]m, "
+            f"buffer={self.cfg.frame_buffer_size}"
+        )
+
+    def _create_volume(self) -> "o3d.pipelines.integration.ScalableTSDFVolume":
+        """Create a fresh Open3D ScalableTSDFVolume."""
+        return o3d.pipelines.integration.ScalableTSDFVolume(
+            voxel_length=self.cfg.voxel_size,
+            sdf_trunc=self.cfg.sdf_trunc,
+            color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8,
+        )
+
+    def _prepare_depth(self, depth_m: np.ndarray) -> np.ndarray:
+        """Clamp depth range and replace NaN with 0 for Open3D."""
+        depth_clean = depth_m.copy()
+        invalid = (
+            ~np.isfinite(depth_clean)
+            | (depth_clean < self.cfg.min_depth_m)
+            | (depth_clean > self.cfg.max_depth_m)
+        )
+        depth_clean[invalid] = 0.0
+        return depth_clean
+
+    def _make_intrinsic(
+        self, K: np.ndarray, width: int, height: int
+    ) -> "o3d.camera.PinholeCameraIntrinsic":
+        """Build Open3D intrinsic from 3x3 K matrix."""
+        return o3d.camera.PinholeCameraIntrinsic(
+            width, height,
+            float(K[0, 0]), float(K[1, 1]),
+            float(K[0, 2]), float(K[1, 2]),
+        )
+
+    def _integrate_single(
+        self,
+        rgb: np.ndarray,
+        depth_clean: np.ndarray,
+        intrinsic: "o3d.camera.PinholeCameraIntrinsic",
+        T_wc: np.ndarray,
+    ) -> None:
+        """Integrate a single frame into the volume (caller holds lock)."""
+        color_o3d = o3d.geometry.Image(
+            np.ascontiguousarray(rgb).astype(np.uint8)
+        )
+        depth_o3d = o3d.geometry.Image(
+            np.ascontiguousarray(depth_clean).astype(np.float32)
+        )
+        rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+            color_o3d, depth_o3d,
+            depth_scale=1.0,        # already in meters
+            depth_trunc=self.cfg.max_depth_m,
+            convert_rgb_to_intensity=False,
+        )
+
+        # Open3D backprojects in OpenCV camera convention (Z-forward, Y-down).
+        # ARKit→OpenCV camera flip is applied at ingestion (WebSocketReceiver)
+        # so T_wc is already in OpenCV convention.
+        # Open3D expects T_cw (camera-from-world) = inverse of T_wc
+        T_cw = np.linalg.inv(T_wc.astype(np.float64))
+        self._volume.integrate(rgbd, intrinsic, T_cw)
+
+    def integrate(
+        self,
+        frame_id: str,
+        rgb: np.ndarray,
+        depth_m: np.ndarray,
+        K: np.ndarray,
+        pose_T_wc: np.ndarray,
+        width: int,
+        height: int,
+        timestamp_ns: int = 0,
+    ) -> bool:
+        """
+        Integrate a single RGB-D frame into the TSDF volume.
+
+        Args:
+            frame_id: Unique identifier for this frame.
+            rgb: (H, W, 3) uint8 RGB image.
+            depth_m: (H, W) float32 depth in meters (NaN = invalid).
+            K: (3, 3) camera intrinsics matrix.
+            pose_T_wc: (4, 4) world-from-camera transform.
+            width: Image width.
+            height: Image height.
+            timestamp_ns: Frame timestamp.
+
+        Returns:
+            True if extraction should be triggered after this integration.
+        """
+        depth_clean = self._prepare_depth(depth_m)
+        intrinsic = self._make_intrinsic(K, width, height)
+        T_wc = pose_T_wc.astype(np.float64)
+
+        with self._lock:
+            self._integrate_single(rgb, depth_clean, intrinsic, T_wc)
+            self._total_integrated += 1
+            self._frames_since_extract += 1
+
+            # Store in ring buffer for re-integration on loop closure
+            self._frame_buffer.append(BufferedFrame(
+                frame_id=frame_id,
+                rgb=rgb.copy(),
+                depth_m=depth_m.copy(),
+                intrinsic=intrinsic,
+                pose=T_wc.copy(),
+                timestamp_ns=timestamp_ns,
+            ))
+
+        # Check if extraction should be triggered
+        now = time.monotonic()
+        should_extract = (
+            self._frames_since_extract >= self.cfg.extract_every_n
+            or (now - self._last_extract_time) >= self.cfg.extract_interval_s
+        )
+        return should_extract
+
+    def extract_point_cloud(self) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Extract the fused point cloud from the TSDF volume.
+
+        Returns:
+            positions: (N, 3) float32 XYZ in world frame.
+            colors: (N, 3) uint8 RGB.
+        """
+        with self._lock:
+            pcd = self._volume.extract_point_cloud()
+            self._frames_since_extract = 0
+            self._last_extract_time = time.monotonic()
+
+        if pcd.is_empty():
+            return (
+                np.zeros((0, 3), dtype=np.float32),
+                np.zeros((0, 3), dtype=np.uint8),
+            )
+
+        positions = np.asarray(pcd.points, dtype=np.float32)
+        colors = (np.asarray(pcd.colors) * 255).astype(np.uint8)
+
+        self._latest_positions = positions
+        self._latest_colors = colors
+        self._mesh_version += 1
+
+        return positions, colors
+
+    def get_latest_mesh(self) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+        """Return the latest extracted mesh, or None if never extracted."""
+        if self._latest_positions is None:
+            return None
+        return self._latest_positions, self._latest_colors
+
+    def handle_pose_corrections(
+        self, corrections: Dict[str, np.ndarray]
+    ) -> bool:
+        """
+        Handle pose corrections from RTAB-Map loop closure.
+
+        Args:
+            corrections: dict mapping frame_id -> corrected 4x4 T_wc pose.
+
+        Returns:
+            True if the volume was reset and re-integrated.
+        """
+        with self._lock:
+            # Find max correction magnitude among buffered frames
+            max_delta = 0.0
+            updated_count = 0
+            for bf in self._frame_buffer:
+                if bf.frame_id in corrections:
+                    old_t = bf.pose[:3, 3]
+                    new_t = corrections[bf.frame_id][:3, 3]
+                    delta = float(np.linalg.norm(new_t - old_t))
+                    max_delta = max(max_delta, delta)
+                    updated_count += 1
+
+            if updated_count == 0:
+                return False
+
+            # Update poses in the buffer
+            for bf in self._frame_buffer:
+                if bf.frame_id in corrections:
+                    bf.pose = corrections[bf.frame_id].astype(np.float64)
+
+            # If corrections are small, TSDF averaging handles it
+            if max_delta < self.cfg.correction_reset_threshold_m:
+                logger.info(
+                    f"[tsdf] Small correction (max {max_delta:.4f}m, "
+                    f"{updated_count} frames), keeping volume"
+                )
+                return False
+
+            # Large correction: reset and re-integrate from buffer
+            logger.info(
+                f"[tsdf] Large correction (max {max_delta:.4f}m, "
+                f"{updated_count} frames), resetting volume and "
+                f"re-integrating {len(self._frame_buffer)} frames"
+            )
+            self._volume = self._create_volume()
+            self._total_integrated = 0
+
+            for bf in self._frame_buffer:
+                depth_clean = self._prepare_depth(bf.depth_m)
+                self._integrate_single(
+                    bf.rgb, depth_clean, bf.intrinsic, bf.pose
+                )
+                self._total_integrated += 1
+
+            # Trigger extraction on next opportunity
+            self._frames_since_extract = self.cfg.extract_every_n
+            return True
+
+    def reset(self) -> None:
+        """Reset the TSDF volume and frame buffer."""
+        with self._lock:
+            self._volume = self._create_volume()
+            self._frame_buffer.clear()
+            self._total_integrated = 0
+            self._frames_since_extract = 0
+            self._latest_positions = None
+            self._latest_colors = None
+            self._mesh_version = 0
+        logger.info("[tsdf] Volume reset")
+
+    @property
+    def total_integrated(self) -> int:
+        return self._total_integrated
+
+    @property
+    def mesh_version(self) -> int:
+        return self._mesh_version
+
+    def stats(self) -> dict:
+        return {
+            "tsdf_total_integrated": self._total_integrated,
+            "tsdf_buffer_size": len(self._frame_buffer),
+            "tsdf_buffer_capacity": self.cfg.frame_buffer_size,
+            "tsdf_mesh_version": self._mesh_version,
+            "tsdf_frames_since_extract": self._frames_since_extract,
+        }

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,375 @@
+"""
+Unit tests for WebSocket receiver data conversion functions and
+depth coordinate scaling in mask_staging.
+"""
+
+from __future__ import annotations
+import json
+import struct
+import math
+import numpy as np
+import cv2
+import torch
+import pytest
+
+from rtsm.io.websocket import decode_rgb, decode_depth, parse_arkit_pose
+from rtsm.utils.transforms import rotmat_to_quat_xyzw, euler_to_quat_xyzw, euler_to_rotation_matrix
+from rtsm.utils.mask_staging import _depth_coords
+
+
+# ─────────────────── decode_rgb ───────────────────
+
+
+class TestDecodeRGB:
+    def test_jpeg(self):
+        img = np.zeros((48, 64, 3), dtype=np.uint8)
+        img[10:30, 10:50] = [0, 128, 255]
+        _, buf = cv2.imencode(".jpg", img, [cv2.IMWRITE_JPEG_QUALITY, 95])
+        result = decode_rgb(buf.tobytes(), "jpeg", 64, 48)
+        assert result.shape == (48, 64, 3)
+        assert result.dtype == np.uint8
+
+    def test_png(self):
+        img = np.ones((32, 32, 3), dtype=np.uint8) * 127
+        _, buf = cv2.imencode(".png", img)
+        result = decode_rgb(buf.tobytes(), "png", 32, 32)
+        assert result.shape == (32, 32, 3)
+        np.testing.assert_array_equal(result, img)
+
+    def test_bgra(self):
+        bgra = np.zeros((16, 16, 4), dtype=np.uint8)
+        bgra[:, :, 0] = 10   # B
+        bgra[:, :, 1] = 20   # G
+        bgra[:, :, 2] = 30   # R
+        bgra[:, :, 3] = 255  # A
+        result = decode_rgb(bgra.tobytes(), "bgra", 16, 16)
+        assert result.shape == (16, 16, 3)
+        assert result[0, 0, 0] == 10  # B
+        assert result[0, 0, 1] == 20  # G
+        assert result[0, 0, 2] == 30  # R
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="Unsupported rgb_format"):
+            decode_rgb(b"\x00", "tiff", 1, 1)
+
+    def test_bgra_size_mismatch_raises(self):
+        with pytest.raises(ValueError, match="bgra buffer size mismatch"):
+            decode_rgb(b"\x00" * 10, "bgra", 16, 16)
+
+
+# ─────────────────── decode_depth ───────────────────
+
+
+class TestDecodeDepth:
+    def test_uint16_mm(self):
+        depth_u16 = np.array([[1500, 0], [2000, 3000]], dtype=np.uint16)
+        raw = depth_u16.tobytes()
+        result = decode_depth(raw, "uint16_mm", 2, 2, depth_scale=0.001)
+        assert result is not None
+        assert result.shape == (2, 2)
+        assert result.dtype == np.float32
+        np.testing.assert_almost_equal(result[0, 0], 1.5)
+        assert np.isnan(result[0, 1]), "zero should become NaN"
+        np.testing.assert_almost_equal(result[1, 0], 2.0)
+        np.testing.assert_almost_equal(result[1, 1], 3.0, decimal=5)
+
+    def test_float32_m(self):
+        depth_f32 = np.array([[1.5, 0.0], [2.0, 3.0]], dtype=np.float32)
+        raw = depth_f32.tobytes()
+        result = decode_depth(raw, "float32_m", 2, 2, depth_scale=1.0)
+        assert result is not None
+        np.testing.assert_almost_equal(result[0, 0], 1.5)
+        assert np.isnan(result[0, 1]), "zero should become NaN"
+
+    def test_png_uint16(self):
+        depth_u16 = np.array([[500, 0], [1000, 0]], dtype=np.uint16)
+        _, buf = cv2.imencode(".png", depth_u16)
+        result = decode_depth(buf.tobytes(), "png_uint16", 2, 2, depth_scale=0.001)
+        assert result is not None
+        np.testing.assert_almost_equal(result[0, 0], 0.5)
+        assert np.isnan(result[0, 1])
+
+    def test_none_format(self):
+        assert decode_depth(b"", None, 0, 0) is None
+
+    def test_empty_bytes(self):
+        assert decode_depth(b"", "uint16_mm", 2, 2) is None
+
+
+# ─────────────────── parse_arkit_pose ───────────────────
+
+
+class TestParseArkitPose:
+    def test_quat_translation(self):
+        # qx, qy, qz, qw, tx, ty, tz
+        data = [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0]
+        t, q = parse_arkit_pose(data, "quat_translation")
+        np.testing.assert_array_almost_equal(t, [1.0, 2.0, 3.0])
+        np.testing.assert_array_almost_equal(q, [0.0, 0.0, 0.0, 1.0])
+
+    def test_matrix4x4_identity(self):
+        # Identity 4x4 in column-major order
+        mat = np.eye(4, dtype=np.float64)
+        data = mat.flatten(order="F").tolist()
+        t, q = parse_arkit_pose(data, "matrix4x4_col_major")
+        np.testing.assert_array_almost_equal(t, [0.0, 0.0, 0.0])
+        # Identity quaternion: [0, 0, 0, 1]
+        np.testing.assert_array_almost_equal(np.abs(q), [0.0, 0.0, 0.0, 1.0], decimal=5)
+
+    def test_matrix4x4_with_translation(self):
+        mat = np.eye(4, dtype=np.float64)
+        mat[:3, 3] = [5.0, 6.0, 7.0]
+        data = mat.flatten(order="F").tolist()
+        t, q = parse_arkit_pose(data, "matrix4x4_col_major")
+        np.testing.assert_array_almost_equal(t, [5.0, 6.0, 7.0])
+
+    def test_quat_wrong_count_raises(self):
+        with pytest.raises(ValueError, match="7 elements"):
+            parse_arkit_pose([1, 2, 3], "quat_translation")
+
+    def test_matrix_wrong_count_raises(self):
+        with pytest.raises(ValueError, match="16 elements"):
+            parse_arkit_pose([1, 2, 3], "matrix4x4_col_major")
+
+    def test_unsupported_format_raises(self):
+        with pytest.raises(ValueError, match="Unsupported pose_format"):
+            parse_arkit_pose([], "euler_xyz")
+
+
+# ─────────────────── rotmat_to_quat_xyzw ───────────────────
+
+
+class TestRotmatToQuat:
+    def test_identity(self):
+        R = np.eye(3, dtype=np.float32)
+        q = rotmat_to_quat_xyzw(R)
+        np.testing.assert_array_almost_equal(q, [0, 0, 0, 1], decimal=5)
+
+    def test_90_deg_around_z(self):
+        # R_z(90°)
+        R = np.array([
+            [0, -1, 0],
+            [1,  0, 0],
+            [0,  0, 1],
+        ], dtype=np.float32)
+        q = rotmat_to_quat_xyzw(R)
+        # Expected: [0, 0, sin(45°), cos(45°)] = [0, 0, 0.7071, 0.7071]
+        np.testing.assert_array_almost_equal(
+            np.abs(q), [0, 0, math.sin(math.pi / 4), math.cos(math.pi / 4)],
+            decimal=4,
+        )
+
+    def test_roundtrip_with_euler(self):
+        """euler → rotation_matrix → rotmat_to_quat should ≈ euler_to_quat."""
+        roll, pitch, yaw = 0.3, -0.2, 1.1
+        q_direct = euler_to_quat_xyzw(roll, pitch, yaw)
+        R = euler_to_rotation_matrix(roll, pitch, yaw)
+        q_via_mat = rotmat_to_quat_xyzw(R)
+        # Quaternion sign ambiguity: q and -q represent the same rotation
+        if np.dot(q_direct, q_via_mat) < 0:
+            q_via_mat = -q_via_mat
+        np.testing.assert_array_almost_equal(q_direct, q_via_mat, decimal=4)
+
+    def test_unit_norm(self):
+        R = euler_to_rotation_matrix(0.5, -0.3, 2.0)
+        q = rotmat_to_quat_xyzw(R)
+        np.testing.assert_almost_equal(np.linalg.norm(q), 1.0, decimal=5)
+
+
+# ─────────────────── _depth_coords ───────────────────
+
+
+class TestDepthCoords:
+    def test_same_shape_noop(self):
+        ys = np.array([0, 10, 20])
+        xs = np.array([5, 15, 25])
+        dy, dx = _depth_coords(ys, xs, (480, 640), (480, 640))
+        np.testing.assert_array_equal(dy, ys)
+        np.testing.assert_array_equal(dx, xs)
+
+    def test_different_shape_scales(self):
+        # Mask is 1440x1920, depth is 192x256
+        ys = np.array([0, 720, 1439])
+        xs = np.array([0, 960, 1919])
+        dy, dx = _depth_coords(ys, xs, (192, 256), (1440, 1920))
+        # y=0 → 0, y=720 → 96, y=1439 → 191 (clipped)
+        assert dy[0] == 0
+        assert 95 <= dy[1] <= 96
+        assert dy[2] == 191
+        # x=0 → 0, x=960 → 128, x=1919 → 255 (clipped)
+        assert dx[0] == 0
+        assert 127 <= dx[1] <= 128
+        assert dx[2] == 255
+
+    def test_depth_quantiles_with_different_resolution(self):
+        """End-to-end: mask at 8x8, depth at 4x4 — should not crash."""
+        from rtsm.utils.mask_staging import _depth_quantiles
+
+        mask = torch.zeros(8, 8, dtype=torch.bool)
+        mask[2:6, 2:6] = True  # 4x4 block of True
+        depth = np.ones((4, 4), dtype=np.float32) * 2.0  # 2 meters everywhere
+        valid_pct, p50, spread = _depth_quantiles(mask, depth)
+        assert valid_pct > 0
+        assert p50 is not None
+        np.testing.assert_almost_equal(p50, 2.0)
+
+    def test_centroid_cam_with_different_resolution(self):
+        """End-to-end: mask at 8x8, depth at 4x4."""
+        from rtsm.utils.mask_staging import _centroid_cam
+
+        mask = torch.zeros(8, 8, dtype=torch.bool)
+        mask[2:6, 2:6] = True
+        depth = np.ones((4, 4), dtype=np.float32) * 1.5
+        c = _centroid_cam(mask, depth, fx=100, fy=100, cx=4, cy=4, stride=1)
+        assert c is not None
+        assert c.shape == (3,)
+        # z should be ~1.5
+        np.testing.assert_almost_equal(c[2], 1.5, decimal=1)
+
+
+# ─────────────────── Binary message parsing ───────────────────
+
+
+def _build_test_frame(**overrides) -> bytes:
+    """Build a minimal valid binary frame for testing."""
+    rgb = np.zeros((48, 64, 3), dtype=np.uint8)
+    rgb[10:30, 10:50] = [0, 128, 255]
+    _, jpeg_buf = cv2.imencode(".jpg", rgb, [cv2.IMWRITE_JPEG_QUALITY, 80])
+    jpeg_bytes = jpeg_buf.tobytes()
+
+    depth_u16 = np.ones((48, 64), dtype=np.uint16) * 1500
+    depth_u16[0, 0] = 0
+    depth_bytes = depth_u16.tobytes()
+
+    header = {
+        "session_id": "test-123",
+        "frame_id": 1,
+        "timestamp_ns": 1000000000,
+        "unix_timestamp": 1700000000.0,
+        "rgb_format": "jpeg",
+        "rgb_width": 64,
+        "rgb_height": 48,
+        "image_orientation": "landscapeRight",
+        "depth_format": "uint16_mm",
+        "depth_width": 64,
+        "depth_height": 48,
+        "depth_scale": 0.001,
+        "fx": 50.0,
+        "fy": 50.0,
+        "cx": 32.0,
+        "cy": 24.0,
+        "intrinsics_width": 64,
+        "intrinsics_height": 48,
+        "pose_format": "quat_translation",
+        "T_wc": [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0],
+        "tracking_state": "normal",
+        "tracking_reason": None,
+        "pose_source": "arkit_vio",
+    }
+    header.update(overrides)
+    json_bytes = json.dumps(header).encode("utf-8")
+
+    msg = b""
+    msg += struct.pack("<I", len(json_bytes))
+    msg += json_bytes
+    msg += struct.pack("<I", len(jpeg_bytes))
+    msg += jpeg_bytes
+    msg += struct.pack("<I", len(depth_bytes))
+    msg += depth_bytes
+    return msg
+
+
+class TestParseBinaryMessage:
+    def _make_receiver(self):
+        from rtsm.io.websocket import WebSocketReceiver
+        from rtsm.io.ingest_queue import IngestQueue
+
+        q = IngestQueue(maxsize=16)
+        recv = WebSocketReceiver(
+            ingest_queue=q,
+            keyframe_every_n=5,
+            nonkf_min_interval_s=0.0,  # disable throttle for testing
+        )
+        return recv, q
+
+    def test_full_roundtrip(self):
+        recv, q = self._make_receiver()
+        data = _build_test_frame()
+        pkt = recv._parse_binary_message(data)
+        assert pkt is not None
+        assert pkt.rgb.shape == (48, 64, 3)
+        assert pkt.depth_m is not None
+        assert pkt.depth_m.shape == (48, 64)
+        assert np.isnan(pkt.depth_m[0, 0]), "zero depth should be NaN"
+        np.testing.assert_almost_equal(pkt.depth_m[1, 1], 1.5)
+        np.testing.assert_array_almost_equal(pkt.pose.t_wc, [1.0, 2.0, 3.0])
+        np.testing.assert_array_almost_equal(pkt.pose.q_wc_xyzw, [0, 0, 0, 1])
+        assert pkt.intr.width == 64
+        assert pkt.intr.height == 48
+        assert pkt.time.t_sensor_ns == 1000000000
+        assert pkt.time.seq == 1
+        assert pkt.is_keyframe  # first frame is always keyframe
+
+    def test_tracking_state_filter(self):
+        recv, q = self._make_receiver()
+        data = _build_test_frame(tracking_state="limited")
+        pkt = recv._parse_binary_message(data)
+        assert pkt is None, "should drop frames with tracking_state != normal"
+
+    def test_truncated_message(self):
+        recv, q = self._make_receiver()
+        pkt = recv._parse_binary_message(b"\x00\x00")
+        assert pkt is None
+
+    def test_intrinsics_scaling(self):
+        recv, q = self._make_receiver()
+        data = _build_test_frame(
+            intrinsics_width=128,
+            intrinsics_height=96,
+            rgb_width=64,
+            rgb_height=48,
+            fx=100.0,
+            fy=100.0,
+            cx=64.0,
+            cy=48.0,
+        )
+        pkt = recv._parse_binary_message(data)
+        assert pkt is not None
+        # Scale is 0.5x in both dimensions
+        np.testing.assert_almost_equal(pkt.intr.fx, 50.0)
+        np.testing.assert_almost_equal(pkt.intr.fy, 50.0)
+        np.testing.assert_almost_equal(pkt.intr.cx, 32.0)
+        np.testing.assert_almost_equal(pkt.intr.cy, 24.0)
+
+    def test_no_depth(self):
+        """Frame with no depth should have depth_m = None."""
+        recv, q = self._make_receiver()
+        # Build frame with no depth
+        rgb = np.zeros((48, 64, 3), dtype=np.uint8)
+        _, jpeg_buf = cv2.imencode(".jpg", rgb)
+        jpeg_bytes = jpeg_buf.tobytes()
+        header = {
+            "session_id": "test",
+            "frame_id": 0,
+            "timestamp_ns": 100,
+            "unix_timestamp": 1700000000.0,
+            "rgb_format": "jpeg",
+            "rgb_width": 64,
+            "rgb_height": 48,
+            "depth_format": None,
+            "depth_width": None,
+            "depth_height": None,
+            "depth_scale": None,
+            "fx": 50.0, "fy": 50.0, "cx": 32.0, "cy": 24.0,
+            "intrinsics_width": 64, "intrinsics_height": 48,
+            "pose_format": "quat_translation",
+            "T_wc": [0, 0, 0, 1, 0, 0, 0],
+            "tracking_state": "normal",
+        }
+        json_bytes = json.dumps(header).encode("utf-8")
+        msg = struct.pack("<I", len(json_bytes)) + json_bytes
+        msg += struct.pack("<I", len(jpeg_bytes)) + jpeg_bytes
+        msg += struct.pack("<I", 0)  # depth_len = 0
+        pkt = recv._parse_binary_message(msg)
+        assert pkt is not None
+        assert pkt.depth_m is None

--- a/tests/test_websocket_e2e.py
+++ b/tests/test_websocket_e2e.py
@@ -1,0 +1,153 @@
+"""
+End-to-end integration test for the WebSocket receiver.
+
+Starts a real WebSocketReceiver on a test port, connects with the
+``websockets`` library, sends a handshake + binary frame, and verifies
+that a FramePacket arrives in the IngestQueue.
+
+Requires: ``pip install websockets``
+"""
+
+from __future__ import annotations
+import asyncio
+import json
+import struct
+import time
+
+import numpy as np
+import cv2
+import pytest
+
+from rtsm.io.websocket import WebSocketReceiver
+from rtsm.io.ingest_queue import IngestQueue
+
+TEST_PORT = 9876
+
+
+def _build_test_frame() -> bytes:
+    """Build a minimal valid binary frame."""
+    rgb = np.zeros((48, 64, 3), dtype=np.uint8)
+    rgb[10:30, 10:50] = [0, 128, 255]
+    _, jpeg_buf = cv2.imencode(".jpg", rgb, [cv2.IMWRITE_JPEG_QUALITY, 80])
+    jpeg_bytes = jpeg_buf.tobytes()
+
+    depth_u16 = np.ones((48, 64), dtype=np.uint16) * 1500
+    depth_u16[0, 0] = 0
+    depth_bytes = depth_u16.tobytes()
+
+    header = {
+        "session_id": "e2e-test",
+        "frame_id": 1,
+        "timestamp_ns": 2000000000,
+        "unix_timestamp": 1700000001.0,
+        "rgb_format": "jpeg",
+        "rgb_width": 64,
+        "rgb_height": 48,
+        "image_orientation": "landscapeRight",
+        "depth_format": "uint16_mm",
+        "depth_width": 64,
+        "depth_height": 48,
+        "depth_scale": 0.001,
+        "fx": 50.0,
+        "fy": 50.0,
+        "cx": 32.0,
+        "cy": 24.0,
+        "intrinsics_width": 64,
+        "intrinsics_height": 48,
+        "pose_format": "quat_translation",
+        "T_wc": [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0],
+        "tracking_state": "normal",
+        "tracking_reason": None,
+        "pose_source": "arkit_vio",
+    }
+    json_bytes = json.dumps(header).encode("utf-8")
+
+    msg = b""
+    msg += struct.pack("<I", len(json_bytes))
+    msg += json_bytes
+    msg += struct.pack("<I", len(jpeg_bytes))
+    msg += jpeg_bytes
+    msg += struct.pack("<I", len(depth_bytes))
+    msg += depth_bytes
+    return msg
+
+
+@pytest.fixture(scope="module")
+def ws_receiver():
+    """Start a WebSocketReceiver on a test port for the module."""
+    q = IngestQueue(maxsize=16)
+    recv = WebSocketReceiver(
+        ingest_queue=q,
+        port=TEST_PORT,
+        keyframe_every_n=5,
+        nonkf_min_interval_s=0.0,
+    )
+    recv.start()
+    time.sleep(1.0)  # let uvicorn bind
+    yield recv, q
+    recv.stop()
+
+
+@pytest.mark.asyncio
+async def test_handshake_and_one_frame(ws_receiver):
+    websockets = pytest.importorskip("websockets")
+    recv, q = ws_receiver
+
+    async with websockets.connect(f"ws://127.0.0.1:{TEST_PORT}/stream") as ws:
+        # Send hello
+        hello = {
+            "type": "hello",
+            "client": "calabi-lens",
+            "protocol_version": 1,
+            "session_id": "e2e-test",
+            "device_name": "pytest",
+        }
+        await ws.send(json.dumps(hello))
+
+        # Receive ack
+        ack_raw = await ws.recv()
+        ack = json.loads(ack_raw)
+        assert ack["type"] == "hello_ack"
+        assert ack["status"] == "ok"
+        assert ack["session_id"] == "e2e-test"
+
+        # Send a binary frame
+        frame = _build_test_frame()
+        await ws.send(frame)
+
+    # Allow time for async processing
+    await asyncio.sleep(0.2)
+
+    # Check queue
+    pkt = q.get(timeout=2.0)
+    assert pkt is not None, "FramePacket should have been enqueued"
+    assert pkt.rgb.shape == (48, 64, 3)
+    assert pkt.depth_m is not None
+    assert pkt.depth_m.shape == (48, 64)
+    np.testing.assert_array_almost_equal(pkt.pose.t_wc, [1.0, 2.0, 3.0])
+
+
+@pytest.mark.asyncio
+async def test_bad_handshake_rejected(ws_receiver):
+    websockets = pytest.importorskip("websockets")
+    recv, q = ws_receiver
+
+    async with websockets.connect(f"ws://127.0.0.1:{TEST_PORT}/stream") as ws:
+        # Send wrong protocol version
+        hello = {
+            "type": "hello",
+            "protocol_version": 99,
+            "session_id": "bad-test",
+        }
+        await ws.send(json.dumps(hello))
+
+        # Should receive error ack
+        ack_raw = await ws.recv()
+        ack = json.loads(ack_raw)
+        assert ack["status"] == "error"
+
+        # Connection should be closed by server
+        try:
+            await ws.recv()
+        except websockets.ConnectionClosed:
+            pass  # expected


### PR DESCRIPTION
## Summary

- **Remove default axis inversion in 3D viewer**: The Three.js world container was defaulting to `scale(-1, -1, -1)`, mirroring the entire point cloud scene and causing object markers and snapshot comparisons to appear inverted
- **Add optional gravity-aligned image rotation for ML inference**: When `device_orientation` is provided by the iOS client, the pipeline rotates images to upright before FastSAM segmentation and CLIP classification, improving model accuracy for non-landscape orientations. All geometry (depth, intrinsics, pose, TSDF) remains in sensor-native space
- **Fix centroid backprojection with retina_masks**: Changed FastSAM from `retina_masks=False` to `retina_masks=True` so masks match the original image resolution, fixing wrong object positions caused by mask-space vs intrinsic-space mismatch. Added a safety fallback that scales intrinsics when mask and RGB resolutions differ

## Changes

### Visualization (`demo/src/main.ts`)
- Set `flippedX`, `flippedY`, `flippedZ` defaults to `false` (was `true`)

### ML orientation rotation (opt-in, no-op when orientation absent)
- `rtsm/core/datamodel.py` — Added `device_orientation` field to `FramePacket`
- `rtsm/io/websocket.py` — Parse `device_orientation` from JSON header
- `rtsm/utils/transforms.py` — Added `orientation_to_rot90_k()`, `rotate_image()`, `unrotate_masks()`
- `rtsm/core/pipeline.py` — Rotate RGB before FastSAM, unrotate masks after, rotate crops before CLIP

### Centroid backprojection fix
- `rtsm/models/segmentation/fastsam_segmenter.py` — `retina_masks=True`
- `rtsm/core/pipeline.py` — Intrinsics scaling fallback when mask resolution differs from RGB


