### PR TITLE
docs: add MCP API page, rewrite installation, add guide pages

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -1,0 +1,166 @@
+# MCP (Model Context Protocol)
+
+RTSM exposes its spatial memory as MCP tools, so any AI agent can query "where is the coffee mug?" without custom REST code. MCP is the standard protocol for connecting AI models to external tools — supported by Claude, Cursor, LangGraph, CrewAI, and others.
+
+## Two Transport Options
+
+| Transport | Use case | How it works |
+|-----------|----------|--------------|
+| **SSE (embedded)** | Agent connects over HTTP | MCP server mounted on RTSM's API server at `/mcp/sse` |
+| **stdio (standalone)** | Agent launches RTSM MCP as a subprocess | `rtsm-mcp` binary, communicates via stdin/stdout |
+
+## Quick Start: SSE (embedded)
+
+### 1. Enable in config
+
+```yaml
+# config/rtsm.yaml
+mcp:
+  enable: true
+```
+
+### 2. Start RTSM
+
+```bash
+pip install "rtsm[gpu]"
+python -m rtsm.run --replay recordings/session1
+```
+
+The MCP endpoint is now live at `http://localhost:8002/mcp/sse`.
+
+### 3. Connect your agent
+
+**Claude Code** — add to your MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "rtsm": {
+      "url": "http://localhost:8002/mcp/sse"
+    }
+  }
+}
+```
+
+**Cursor** — add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rtsm": {
+      "url": "http://localhost:8002/mcp/sse"
+    }
+  }
+}
+```
+
+**Python (any agent framework):**
+
+```python
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+
+async with sse_client("http://localhost:8002/mcp/sse") as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+
+        # Query spatial memory
+        result = await session.call_tool(
+            "rtsm.semantic_query",
+            arguments={"query": "coffee mug", "top_k": 3}
+        )
+        print(result.content[0].text)
+```
+
+## Quick Start: stdio (standalone)
+
+The stdio transport is useful when your agent framework launches MCP servers as subprocesses.
+
+### 1. Install
+
+```bash
+pip install "rtsm[gpu]"
+```
+
+### 2. Configure your agent
+
+**Claude Code** — add to MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "rtsm": {
+      "command": "rtsm-mcp",
+      "env": {
+        "RTSM_API_URL": "http://localhost:8002"
+      }
+    }
+  }
+}
+```
+
+The `rtsm-mcp` command connects to a running RTSM instance via its REST API and exposes the same 6 tools over stdio.
+
+## Available Tools
+
+| Tool | Description | Example use |
+|------|-------------|-------------|
+| `rtsm.semantic_query` | Search by natural language | "where is the coffee mug?" |
+| `rtsm.spatial_query` | Find objects near a 3D point | Objects within 2m of [1.0, 0.5, 0.8] |
+| `rtsm.relational_query` | Find objects near a named object | "what is next to the laptop?" |
+| `rtsm.list_objects` | List all tracked objects | Get full scene inventory |
+| `rtsm.get_object` | Get details for one object | Full info by object ID |
+| `rtsm.status` | System health and stats | Pipeline status, object counts |
+
+### Tool Parameters
+
+**`rtsm.semantic_query`**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | required | Natural language search query |
+| `top_k` | int | 5 | Max results to return |
+| `threshold` | float | 0.2 | Min cosine similarity (0-1) |
+
+**`rtsm.spatial_query`**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `x` | float | required | X coordinate (meters) |
+| `y` | float | required | Y coordinate (meters) |
+| `z` | float | required | Z coordinate (meters) |
+| `radius_m` | float | 1.0 | Search radius in meters |
+
+**`rtsm.relational_query`**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | string | required | Name of reference object |
+| `radius_m` | float | 1.0 | Search radius in meters |
+
+**`rtsm.get_object`**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `object_id` | string | required | Object ID |
+| `include_vectors` | bool | false | Include embedding vectors |
+
+## Example: Agent Asks "Where is the mug?"
+
+```
+Agent → rtsm.semantic_query(query="mug", top_k=1)
+
+RTSM → {
+  "objects": [
+    {
+      "id": "obj_231",
+      "label": "mug",
+      "xyz": [2.31, -0.15, 1.18],
+      "confidence": 0.85,
+      "last_seen": "2026-04-07T10:23:15Z"
+    }
+  ]
+}
+```
+
+The agent now knows the mug is at position [2.31, -0.15, 1.18] in world coordinates and can plan accordingly.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,46 +3,104 @@
 ## Prerequisites
 
 - Python 3.12+
-- CUDA-capable GPU (tested on RTX 3080, RTX 5090)
-- RGB-D camera (Intel RealSense D435i tested)
-- SLAM system providing poses (RTAB-Map, ORB-SLAM3)
-
-!!! note "WSL2 Users"
-    Tested on WSL2 Ubuntu 22.04 with RTAB-Map. WSL2 has USB passthrough limitations — you may need [usbipd-win](https://github.com/dorssel/usbipd-win) for camera access.
+- CUDA-capable GPU (tested on RTX 3080, RTX 4090, RTX 5090)
+- For live capture: iPhone with [Calabi Lens](https://github.com/calabi-inc/rtsm-arkit-client) or Intel RealSense D435i + RTAB-Map
+- For demo/replay: no hardware needed
 
 ---
 
 ## Install RTSM
 
+### Option A: pip install (recommended)
+
+```bash
+# Core only (query client, REST API, data contracts — no GPU needed)
+pip install rtsm
+
+# With GPU perception pipeline (default: Grounding DINO + SAM2, Apache 2.0)
+pip install "rtsm[gpu]" --extra-index-url https://download.pytorch.org/whl/cu128
+
+# With 3D visualization
+pip install "rtsm[gpu,viz]" --extra-index-url https://download.pytorch.org/whl/cu128
+
+# Everything
+pip install "rtsm[all]" --extra-index-url https://download.pytorch.org/whl/cu128
+```
+
+!!! tip "CUDA Version"
+    The `--extra-index-url` flag tells pip which PyTorch build to use. Replace `cu128` with your CUDA version:
+
+    - CUDA 11.8: `https://download.pytorch.org/whl/cu118`
+    - CUDA 12.1: `https://download.pytorch.org/whl/cu121`
+    - CUDA 12.8: `https://download.pytorch.org/whl/cu128`
+
+### Option B: from source (development)
+
 ```bash
 git clone https://github.com/calabi-inc/rtsm.git
 cd rtsm
-# Install dependencies
-pip install -r requirements.txt
-
-# Install RTSM in editable mode
-pip install -e .
+pip install -e ".[gpu,viz]" --extra-index-url https://download.pytorch.org/whl/cu128
 ```
+
+### Option C: faster backends (AGPL, opt-in)
+
+The default backends (Grounding DINO + SAM2) are Apache 2.0 licensed. For faster inference using FastSAM + YOLOE (AGPL-3.0 via ultralytics), install the opt-in extra:
+
+```bash
+pip install "rtsm[gpu-ultralytics]" --extra-index-url https://download.pytorch.org/whl/cu128
+```
+
+Then set `backend: dual` in your config. See [Configuration](configuration.md) for details.
 
 ---
 
-## Download Models
+## Install Extras
 
-### FastSAM Weights
+| Extra | What it adds | License |
+|-------|-------------|---------|
+| `gpu` | Grounding DINO, SAM2, CLIP, torch, FAISS | Apache 2.0 |
+| `gpu-ultralytics` | FastSAM, YOLOE (via ultralytics) | AGPL-3.0 |
+| `viz` | Open3D, matplotlib (3D visualization) | MIT |
+| `mcp` | MCP server + httpx (AI agent integration) | Apache 2.0 |
+| `all` | gpu + viz + mcp | Mixed |
 
-```bash
-mkdir -p model_store/fastsam
-# Download FastSAM-x.pt to model_store/fastsam/
-```
+---
 
-Download from: [FastSAM Releases](https://github.com/CASIA-IVA-Lab/FastSAM/releases)
+## Model Weights
 
-### CLIP Weights
+### Permissive backends (default)
 
-CLIP weights are auto-downloaded on first run, or you can pre-fetch:
+All models **auto-download on first run** via HuggingFace Hub. No manual setup needed.
 
-```bash
-python scripts/fetch_clip.py
+| Model | HuggingFace ID | Size | Auto-download |
+|-------|---------------|------|:---:|
+| Grounding DINO (tiny) | `IDEA-Research/grounding-dino-tiny` | ~340MB | Yes |
+| SAM2.1 Hiera (small) | `facebook/sam2.1-hiera-small` | ~160MB | Yes |
+| CLIP ViT-B/32 | `openai/clip-vit-base-patch32` (via open_clip) | ~340MB | Yes |
+
+First run will download ~840MB of model weights to your HuggingFace cache (`~/.cache/huggingface/`). Subsequent runs use the cache.
+
+### AGPL backends (opt-in)
+
+| Model | Source | Size | Auto-download |
+|-------|--------|------|:---:|
+| FastSAM-x | ultralytics (auto-downloads) | ~140MB | Yes |
+| YOLOE-26s-seg | ultralytics (auto-downloads) | ~50MB | Yes |
+
+### Pre-download (optional)
+
+To avoid download delays on first run:
+
+```python
+# Pre-download permissive models
+from transformers import AutoProcessor, AutoModelForZeroShotObjectDetection
+AutoModelForZeroShotObjectDetection.from_pretrained("IDEA-Research/grounding-dino-tiny")
+
+from sam2.build_sam import build_sam2
+# SAM2 downloads automatically via sam2 package
+
+import open_clip
+open_clip.create_model_and_transforms("ViT-B-32", pretrained="openai")
 ```
 
 ---
@@ -50,12 +108,44 @@ python scripts/fetch_clip.py
 ## Verify Installation
 
 ```bash
-python -c "import rtsm; print(rtsm.__version__)"
+# Check import works
+python -c "import rtsm; print('RTSM ready')"
+
+# Check GPU pipeline loads (requires [gpu] extra)
+python -c "from rtsm.models.segmentation import get_segmenter; print('Segmentation ready')"
 ```
+
+---
+
+## Docker
+
+```bash
+# GPU pipeline (requires nvidia-docker)
+docker run --gpus all calabi/rtsm demo
+```
+
+!!! note "Docker Images"
+    Pre-built Docker images are planned for a future release. For now, use the Dockerfiles in `tests/` for reference:
+
+    - `tests/Dockerfile.deptest` — Dependency verification (core, GPU, full)
+    - `tests/Dockerfile.gpu-test` — GPU pipeline replay test
+
+---
+
+## Install MCP Support (Optional)
+
+To expose RTSM as an MCP tool server for AI agents (Claude, Cursor, LangGraph, etc.):
+
+```bash
+pip install "rtsm[gpu,mcp]" --extra-index-url https://download.pytorch.org/whl/cu128
+```
+
+See [MCP (AI Agents)](../api/mcp.md) for setup and configuration.
 
 ---
 
 ## Next Steps
 
-- [Quick Start](quick-start.md) — Run your first query
-- [Configuration](configuration.md) — Customize for your setup
+- [Quick Start](quick-start.md) — Run your first session
+- [Configuration](configuration.md) — Choose backends and tune parameters
+- [MCP (AI Agents)](../api/mcp.md) — Connect your AI agent to RTSM

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -122,8 +122,47 @@ Open the visualization frontend in your browser. The 3D viewer connects to the W
 
 ---
 
+## 7. Record and Replay Sessions
+
+Record a live session for later replay and benchmarking:
+
+```bash
+# Record while running pipeline
+python -m rtsm --record recordings/my_session
+
+# Record without GPU (raw frame capture only)
+python -m rtsm --record recordings/my_session --record-only
+```
+
+Replay a recorded session:
+
+```bash
+python -m rtsm --replay recordings/session1
+```
+
+This feeds the recorded frames through the full pipeline at the original recording rate — no camera hardware needed. See the [Record & Replay Guide](../guides/record-replay.md) for details.
+
+---
+
+## 8. Check Analytics (Optional)
+
+While a session is running (live or replay), view runtime analytics:
+
+```bash
+# Per-stage latency breakdown
+curl http://localhost:8002/stats/detailed
+
+# Segmentation analytics (mask counts, confirmation rates)
+curl http://localhost:8002/analytics/segmentation
+```
+
+The analytics dashboard is also available in the 3D visualization frontend as a separate tab. See the [Analytics Dashboard Guide](../guides/analytics-dashboard.md) for details.
+
+---
+
 ## Next Steps
 
 - [Configuration](configuration.md) — Tune thresholds and endpoints
 - [REST API Reference](../api/rest-api.md) — Full API documentation
+- [Record & Replay](../guides/record-replay.md) — Capture and replay sessions
 - [RTAB-Map Setup](../guides/rtabmap-setup.md) — Connect your SLAM system

--- a/docs/guides/analytics-dashboard.md
+++ b/docs/guides/analytics-dashboard.md
@@ -1,0 +1,102 @@
+# Analytics Dashboard
+
+RTSM includes a runtime analytics system that tracks per-stage latency, segmentation output, and pipeline throughput. Analytics are available via the REST API and the built-in visualization dashboard.
+
+---
+
+## Enabling Analytics
+
+Analytics are enabled by default. Configure in `config/rtsm.yaml`:
+
+```yaml
+analytics:
+  enable: true
+  retention_s: 3600     # Keep 1 hour of data
+  buffer_frames: 300    # Ring buffer size (per-frame granularity)
+```
+
+---
+
+## REST API Endpoints
+
+### Pipeline latency
+
+```bash
+curl http://localhost:8002/stats/detailed
+```
+
+Returns per-stage timing breakdown:
+
+| Stage | Description |
+|-------|-------------|
+| `segmentation` | Mask extraction (model inference) |
+| `heuristics` | Mask filtering (area, depth, border, planarity) |
+| `scoring` | Priority scoring and top-K selection |
+| `clip` | CLIP visual encoding (224x224 crops) |
+| `association` | Proximity + embedding matching to existing objects |
+
+Each stage reports mean, P50, P95, and max latency.
+
+### Segmentation analytics
+
+```bash
+curl http://localhost:8002/analytics/segmentation
+```
+
+Returns segmentation-specific metrics:
+
+- Masks per frame (mean, min, max)
+- Dual-confirmation rate (when using `dual` backend)
+- Label distribution across confirmed objects
+- Drop counters (frames rejected at each gate)
+
+### Drop counters
+
+The pipeline tracks where frames are dropped:
+
+| Drop point | Description |
+|------------|-------------|
+| `tracking_state` | Camera tracking quality below threshold |
+| `throttle` | Non-keyframe interval throttling |
+| `queue_full` | Ingest queue overflow |
+| `gate_rejection` | Sweep-based novelty gating |
+
+---
+
+## Visualization Dashboard
+
+The analytics dashboard is built into the 3D visualization frontend. When the visualization server is running (`ws://localhost:8083/ws`), the frontend includes:
+
+- **KPI Scorecards** — Input Hz, Processing Hz, Latency, Queue depth, Object count, Association rate
+- **Time-series charts** — Throughput, per-stage latency breakdown, segmentation rates (powered by uPlot)
+- **Config display** — Current backend, filtering thresholds, and scoring parameters
+
+The dashboard updates in real-time via WebSocket push from the visualization server.
+
+---
+
+## Prometheus Metrics
+
+RTSM exports Prometheus-compatible metrics at `http://localhost:8002/metrics`:
+
+```bash
+curl http://localhost:8002/metrics
+```
+
+Key gauges:
+
+| Metric | Description |
+|--------|-------------|
+| `rtsm_live_objects` | Current number of live objects |
+| `rtsm_confirmed_objects` | Number of confirmed objects |
+| `rtsm_upserts_total` | Total vector DB upserts |
+
+These can be scraped by Prometheus and visualized in Grafana for long-term monitoring.
+
+---
+
+## Next Steps
+
+- [Benchmarks](../benchmarks.md) — Backend comparison with analytics data
+- [REST API Reference](../api/rest-api.md) — Full API documentation
+- [Record & Replay](record-replay.md) — Capture sessions for offline analysis

--- a/docs/guides/record-replay.md
+++ b/docs/guides/record-replay.md
@@ -1,0 +1,86 @@
+# Record & Replay
+
+RTSM can record live WebSocket sessions to disk and replay them through the full pipeline at the original rate. This enables reproducible benchmarking and offline testing without camera hardware.
+
+---
+
+## Recording a Session
+
+### Record while running the pipeline
+
+Stream frames from a camera while running the full perception pipeline:
+
+```bash
+python -m rtsm --record recordings/my_session
+```
+
+This writes raw binary frames and metadata to the specified directory while processing them normally.
+
+### Record without GPU (raw capture)
+
+Capture raw frames without running segmentation or CLIP — useful for quick capture on a laptop without a GPU:
+
+```bash
+python -m rtsm --record recordings/my_session --record-only
+```
+
+!!! tip
+    `--record-only` mode requires no GPU dependencies. Install with just `pip install rtsm` (core only).
+
+### What gets recorded
+
+Each recording session creates a directory with:
+
+| File | Contents |
+|------|----------|
+| `messages.bin` | Raw binary WebSocket frames (RGB + depth + pose) |
+| `index.jsonl` | Per-frame metadata (timestamps, offsets, sizes) |
+| `meta.json` | Session metadata (config snapshot, device info) |
+
+---
+
+## Replaying a Session
+
+Feed a recorded session through the full pipeline:
+
+```bash
+python -m rtsm --replay recordings/session1
+```
+
+This launches the complete RTSM stack (segmentation, CLIP, association, memory, API, visualization) and replays frames at the original recording rate.
+
+### Included test dataset
+
+RTSM ships with a test recording for quick verification:
+
+```bash
+# 162-frame bedroom scan (~458 seconds, iPhone ARKit via Calabi Lens)
+python -m rtsm --replay recordings/session1
+```
+
+The recording is stored with git-lfs. After cloning, run `git lfs pull` if the binary files aren't downloaded.
+
+---
+
+## Use Cases
+
+- **Benchmarking** — Compare segmentation backends on the same input frames
+- **Debugging** — Reproduce pipeline issues without needing the camera
+- **CI/CD** — Run automated pipeline tests with deterministic input
+- **A/B testing** — Use `scripts/debug_segmentation.py` to generate side-by-side comparisons
+
+### A/B segmentation comparison
+
+```bash
+python scripts/debug_segmentation.py --recording recordings/session1
+```
+
+This generates an HTML viewer in `debug/session1/compare.html` showing FastSAM vs YOLOE overlays per frame.
+
+---
+
+## Next Steps
+
+- [Quick Start](../getting-started/quick-start.md) — Run your first session
+- [Benchmarks](../benchmarks.md) — Full performance comparison
+- [Configuration](../getting-started/configuration.md) — Tune backends and thresholds

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,10 @@ This makes spatial state inspectable, queryable, and reusable across robots, age
 - **Real-time** — 210 ms mean pipeline latency (dual backend, RTX 5090)
 - **Persistent memory** — Objects tracked across views with stable IDs, promoted from proto to confirmed
 - **Semantic search** — Find objects by natural language via CLIP embeddings + FAISS
+- **Spatial search** — Find objects near 3D world coordinates or relative to other objects
+- **MCP integration** — AI agents (Claude, Cursor, LangGraph) can query spatial memory via Model Context Protocol
+- **Record & replay** — Capture live sessions for offline benchmarking and reproducible testing
+- **Runtime analytics** — Per-stage latency, segmentation rates, and throughput dashboards
 - **Queryable API** — REST endpoints for objects, search, stats, and analytics
 
 ```json
@@ -48,6 +52,7 @@ This makes spatial state inspectable, queryable, and reusable across robots, age
 - :material-cog: **[Configuration](getting-started/configuration.md)** — Tune for your setup
 - :material-api: **[REST API](api/rest-api.md)** — API reference
 - :material-chart-bar: **[Benchmarks](benchmarks.md)** — Performance data
+- :material-robot: **[MCP (AI Agents)](api/mcp.md)** — Connect AI agents to spatial memory
 
 </div>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,9 +39,12 @@ nav:
       - Memory Model: concepts/memory-model.md
   - API Reference:
       - REST API: api/rest-api.md
+      - MCP (AI Agents): api/mcp.md
       - WebSocket: api/websocket.md
   - Benchmarks: benchmarks.md
   - Guides:
+      - Record & Replay: guides/record-replay.md
+      - Analytics Dashboard: guides/analytics-dashboard.md
       - RTAB-Map Setup: guides/rtabmap-setup.md
       - RealSense Setup: guides/realsense-setup.md
   - Contributing: contributing.md
@@ -67,4 +70,4 @@ extra:
       link: https://github.com/calabi-inc/rtsm
   generator: false
 
-copyright: Copyright &copy; 2025 Calabi Inc.
+copyright: Copyright &copy; 2025-2026 Calabi Inc.


### PR DESCRIPTION
## Summary

- **MCP documentation** — dedicated `docs/api/mcp.md` with SSE + stdio setup, copy-paste configs for Claude Code/Cursor/Python, all 6 tools with parameters and examples
- **Installation rewrite** — covers all extras (`gpu`, `gpu-ultralytics`, `viz`, `mcp`), all model weights with auto-download info and HuggingFace IDs, CUDA version guide, removed stale `requirements.txt` references
- **New guide pages** — Record & Replay, Analytics Dashboard
- **Nav updates** — MCP page in API Reference, new guides in sidebar

## Test plan

- [x] All new/modified markdown files render correctly in mkdocs
- [x] Links between pages resolve (installation → mcp, quick-start → mcp)
- [x] No broken references to deleted files (requirements.txt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)