### PR TITLE
fix(io): robot_pose at WebSocket receive time (~5 Hz) instead of pipeline rate (~1 Hz)

### DIFF
--- a/rtsm/io/websocket.py
+++ b/rtsm/io/websocket.py
@@ -545,6 +545,9 @@ class WebSocketReceiver:
 
         # 5b. Parse pose + wall timestamp (hoisted above the keyframe/interval
         # throttle so the pose sink fires at the full input rate).
+        # Note: a malformed T_wc now raises here — before frame_count
+        # increments — instead of after image decode; the caller catches and
+        # logs it per frame.
         t_wc, q_xyzw = parse_arkit_pose(
             T_wc_data=header["T_wc"],
             pose_format=header.get("pose_format", "matrix4x4_col_major"),
@@ -561,7 +564,11 @@ class WebSocketReceiver:
             t_wc = T_wc_mat[:3, 3].astype(np.float32)
             q_xyzw = rotmat_to_quat_xyzw(T_wc_mat[:3, :3].astype(np.float32))
 
-        unix_ts = float(header.get("unix_timestamp", time.time()))
+        # Treat a missing/zero unix_timestamp as absent and substitute server
+        # wall time; the same value flows into TimeBundle.t_wall_utc_s, so the
+        # pose sink and the pipeline's later update_robot_pose call always
+        # share one clock (the guard compares timestamps across the two).
+        unix_ts = float(header.get("unix_timestamp") or time.time())
 
         # 5c. Pose sink: latest-pose passthrough for every tracking-normal
         # frame, even ones the throttle below skips. Same (post-flip) pose the

--- a/rtsm/io/websocket.py
+++ b/rtsm/io/websocket.py
@@ -220,6 +220,7 @@ class WebSocketReceiver:
         on_pose_corrections_batch: Optional[callable] = None,
         on_raw_message: Optional[callable] = None,
         on_handshake_done: Optional[callable] = None,
+        pose_sink: Optional[callable] = None,
         latency_analytics: Optional[Any] = None,
     ) -> None:
         self.ingest_q = ingest_queue
@@ -236,6 +237,11 @@ class WebSocketReceiver:
         self._on_pose_corrections_batch = on_pose_corrections_batch
         self._on_raw_message = on_raw_message
         self._on_handshake_done = on_handshake_done
+        # Called as pose_sink(t_wc, q_wc_xyzw, unix_ts) for EVERY frame with
+        # normal tracking — including frames the keyframe/interval throttle
+        # skips — so consumers (e.g. WorkingMemory.update_robot_pose) see
+        # pose at the full input rate, not the pipeline processing rate.
+        self._pose_sink = pose_sink
         self._latency_analytics = latency_analytics
 
         # Per-session state (reset on each new client connection)
@@ -537,6 +543,35 @@ class WebSocketReceiver:
             )
             return None
 
+        # 5b. Parse pose + wall timestamp (hoisted above the keyframe/interval
+        # throttle so the pose sink fires at the full input rate).
+        t_wc, q_xyzw = parse_arkit_pose(
+            T_wc_data=header["T_wc"],
+            pose_format=header.get("pose_format", "matrix4x4_col_major"),
+        )
+
+        # Camera convention flip: ARKit (Y-up, Z-back) → OpenCV (Y-down, Z-forward)
+        # Applied once at ingestion so ALL downstream consumers (pipeline, TSDF,
+        # visualization, sweep cache, pose sink) see poses in OpenCV camera
+        # convention.
+        if self._apply_camera_flip:
+            T_wc_mat = PoseStamped(
+                stamp_ns=0, frame_id="", t_wc=t_wc, q_wc_xyzw=q_xyzw
+            ).T_wc() @ _ARKIT_TO_OPENCV
+            t_wc = T_wc_mat[:3, 3].astype(np.float32)
+            q_xyzw = rotmat_to_quat_xyzw(T_wc_mat[:3, :3].astype(np.float32))
+
+        unix_ts = float(header.get("unix_timestamp", time.time()))
+
+        # 5c. Pose sink: latest-pose passthrough for every tracking-normal
+        # frame, even ones the throttle below skips. Same (post-flip) pose the
+        # FramePacket carries, so consumers see one consistent convention.
+        if self._pose_sink is not None:
+            try:
+                self._pose_sink(t_wc, q_xyzw, unix_ts)
+            except Exception as e:
+                logger.error(f"[websocket] pose_sink callback error: {e}")
+
         self._frame_count += 1
 
         # 5. Keyframe decision
@@ -570,21 +605,8 @@ class WebSocketReceiver:
             depth_scale=depth_scale,
         )
 
-        # 9. Parse pose
-        t_wc, q_xyzw = parse_arkit_pose(
-            T_wc_data=header["T_wc"],
-            pose_format=header.get("pose_format", "matrix4x4_col_major"),
-        )
-
-        # 9b. Camera convention flip: ARKit (Y-up, Z-back) → OpenCV (Y-down, Z-forward)
-        # Applied once at ingestion so ALL downstream consumers (pipeline, TSDF,
-        # visualization, sweep cache) see poses in OpenCV camera convention.
-        if self._apply_camera_flip:
-            T_wc_mat = PoseStamped(
-                stamp_ns=0, frame_id="", t_wc=t_wc, q_wc_xyzw=q_xyzw
-            ).T_wc() @ _ARKIT_TO_OPENCV
-            t_wc = T_wc_mat[:3, 3].astype(np.float32)
-            q_xyzw = rotmat_to_quat_xyzw(T_wc_mat[:3, :3].astype(np.float32))
+        # 9. Pose already parsed (+ convention flip) in step 5b above; the
+        # same t_wc / q_xyzw feed both the pose sink and the FramePacket.
 
         # 10. Build intrinsics (scale if intrinsics resolution differs from RGB)
         intr_w = int(header.get("intrinsics_width", rgb_w))
@@ -608,9 +630,8 @@ class WebSocketReceiver:
             fx=fx, fy=fy, cx=cx, cy=cy,
         )
 
-        # 11. Build TimeBundle
+        # 11. Build TimeBundle (unix_ts computed in step 5b)
         timestamp_ns = int(header.get("timestamp_ns", 0))
-        unix_ts = float(header.get("unix_timestamp", time.time()))
 
         tb = TimeBundle(
             t_mono_s=time.monotonic(),

--- a/rtsm/run.py
+++ b/rtsm/run.py
@@ -280,6 +280,10 @@ def main():
             on_pose_corrections_batch=vis_server.handle_pose_corrections_batch if vis_server else None,
             on_raw_message=recorder.on_message if recorder else None,
             on_handshake_done=recorder.on_handshake if recorder else None,
+            # Receive-time robot pose passthrough: agents polling robot_pose
+            # get input-rate freshness (~5 Hz) instead of the pipeline's
+            # sweep-gated processing rate (~1 Hz).
+            pose_sink=wm.update_robot_pose,
             latency_analytics=latency_analytics,
         )
         ws_receiver.start()

--- a/rtsm/stores/working_memory.py
+++ b/rtsm/stores/working_memory.py
@@ -167,8 +167,11 @@ class WorkingMemory:
 
         self._map: Dict[str, ObjectState] = {}
         self._lock = threading.RLock()
-        # Latest robot pose — passthrough from sensor, updated every processed frame
+        # Latest robot pose — passthrough from sensor (receive-time in live
+        # websocket mode; per processed frame on ZMQ/replay paths).
         self._latest_pose: Optional[Dict[str, Any]] = None
+        # Process-monotonic arrival time of the stored pose (guard window).
+        self._latest_pose_arrival_mono: float = 0.0
         # Reverse index: frame_id -> set of object IDs last updated on that frame
         self._frame_to_objects: Dict[str, set] = {}
         # Min-heap of (deadline_mono, oid) for proto expiry (lazy re-schedule on matches)
@@ -763,6 +766,12 @@ class WorkingMemory:
 
     # ---------- utilities ----------
 
+    # How long (by this process's monotonic clock) a stored pose out-ranks
+    # older-timestamped updates. Long enough to block the slow pipeline
+    # write (~0.5-1 s behind), short enough that a sender clock stepping
+    # backward (new device, NTP) recovers instead of freezing the pose.
+    _POSE_GUARD_WINDOW_S = 2.0
+
     def update_robot_pose(self, t_wc: np.ndarray, q_wc_xyzw: np.ndarray, timestamp: float) -> None:
         """Store latest robot pose (passthrough from sensor).
 
@@ -771,22 +780,35 @@ class WorkingMemory:
 
         May be called from two writers: the receiver at frame-receive time
         (fresh, input-rate) and the pipeline after processing (older frames).
-        Updates carrying a strictly older timestamp than the stored pose are
-        ignored, so a slow pipeline write can never overwrite a fresher
-        receive-time pose. Timestamps must come from the same clock per
-        session (FramePacket wall time).
+        Guarded compare-and-set under the WM lock: an update carrying a
+        strictly older timestamp is ignored while the stored pose is fresh
+        (received less than _POSE_GUARD_WINDOW_S ago), so a slow pipeline
+        write cannot overwrite a fresher receive-time pose — but a sender
+        clock discontinuity self-heals within the window rather than
+        rejecting all future updates. Timestamps must come from the same
+        clock per session (FramePacket wall time).
         """
         ts = float(timestamp)
-        if self._latest_pose is not None and ts < self._latest_pose["timestamp"]:
-            return
-        self._latest_pose = {
-            "xyz": t_wc.tolist() if hasattr(t_wc, 'tolist') else list(t_wc),
-            "quaternion_xyzw": q_wc_xyzw.tolist() if hasattr(q_wc_xyzw, 'tolist') else list(q_wc_xyzw),
-            "timestamp": ts,
-        }
+        now_mono = time.monotonic()
+        with self._lock:
+            lp = self._latest_pose
+            if (
+                lp is not None
+                and ts < lp["timestamp"]
+                and (now_mono - self._latest_pose_arrival_mono) < self._POSE_GUARD_WINDOW_S
+            ):
+                return
+            self._latest_pose = {
+                "xyz": t_wc.tolist() if hasattr(t_wc, 'tolist') else list(t_wc),
+                "quaternion_xyzw": q_wc_xyzw.tolist() if hasattr(q_wc_xyzw, 'tolist') else list(q_wc_xyzw),
+                "timestamp": ts,
+            }
+            self._latest_pose_arrival_mono = now_mono
 
     def get_robot_pose(self) -> Optional[Dict[str, Any]]:
-        """Get the latest robot pose, or None if no frames processed yet."""
+        """Get the latest robot pose, or None if no frame has arrived yet
+        (live websocket: first *received* frame; ZMQ/replay: first
+        *processed* frame)."""
         return self._latest_pose
 
     def stats(self) -> Dict[str, Any]:
@@ -835,6 +857,7 @@ class WorkingMemory:
             # update_robot_pose() can't reject re-fed older timestamps
             # (e.g. replaying a recording after a /reset).
             self._latest_pose = None
+            self._latest_pose_arrival_mono = 0.0
 
             logger.info(f"[WM] Cleared {obj_count} objects ({confirmed_count} confirmed, {proto_count} proto)")
 

--- a/rtsm/stores/working_memory.py
+++ b/rtsm/stores/working_memory.py
@@ -768,11 +768,21 @@ class WorkingMemory:
 
         RTSM does NOT compute or filter pose — it stores what the sensor provides.
         This allows agents to query robot position + object positions atomically.
+
+        May be called from two writers: the receiver at frame-receive time
+        (fresh, input-rate) and the pipeline after processing (older frames).
+        Updates carrying a strictly older timestamp than the stored pose are
+        ignored, so a slow pipeline write can never overwrite a fresher
+        receive-time pose. Timestamps must come from the same clock per
+        session (FramePacket wall time).
         """
+        ts = float(timestamp)
+        if self._latest_pose is not None and ts < self._latest_pose["timestamp"]:
+            return
         self._latest_pose = {
             "xyz": t_wc.tolist() if hasattr(t_wc, 'tolist') else list(t_wc),
             "quaternion_xyzw": q_wc_xyzw.tolist() if hasattr(q_wc_xyzw, 'tolist') else list(q_wc_xyzw),
-            "timestamp": float(timestamp),
+            "timestamp": ts,
         }
 
     def get_robot_pose(self) -> Optional[Dict[str, Any]]:
@@ -820,6 +830,11 @@ class WorkingMemory:
             # Clear attached spatial index if present
             if self.index is not None:
                 self.index.clear()
+
+            # Reset stored robot pose so the monotonic-timestamp guard in
+            # update_robot_pose() can't reject re-fed older timestamps
+            # (e.g. replaying a recording after a /reset).
+            self._latest_pose = None
 
             logger.info(f"[WM] Cleared {obj_count} objects ({confirmed_count} confirmed, {proto_count} proto)")
 

--- a/tests/test_pose_receive_time.py
+++ b/tests/test_pose_receive_time.py
@@ -1,0 +1,197 @@
+"""
+Tests for receive-time robot pose passthrough.
+
+Covers:
+- WorkingMemory.update_robot_pose monotonic-timestamp guard (a slow pipeline
+  write must not overwrite a fresher receive-time pose) and clear() reset.
+- WebSocketReceiver pose_sink firing at input rate — including frames the
+  keyframe/interval throttle skips — with the same post-flip pose the
+  FramePacket carries.
+"""
+
+from __future__ import annotations
+import json
+import struct
+import time
+
+import numpy as np
+import cv2
+import pytest
+
+from rtsm.io.ingest_queue import IngestQueue
+from rtsm.io.websocket import WebSocketReceiver
+from rtsm.stores.working_memory import WorkingMemory
+
+
+# ─────────────────── update_robot_pose guard ───────────────────
+
+
+class TestUpdateRobotPoseGuard:
+    def _wm(self) -> WorkingMemory:
+        return WorkingMemory(cfg={})
+
+    def test_first_write_stored(self):
+        wm = self._wm()
+        wm.update_robot_pose(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0, 1.0]), 100.0)
+        pose = wm.get_robot_pose()
+        assert pose is not None
+        assert pose["xyz"] == [1.0, 2.0, 3.0]
+        assert pose["timestamp"] == 100.0
+
+    def test_newer_overwrites(self):
+        wm = self._wm()
+        wm.update_robot_pose(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0, 1.0]), 100.0)
+        wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), np.array([0, 0, 0, 1.0]), 101.0)
+        assert wm.get_robot_pose()["xyz"] == [4.0, 5.0, 6.0]
+
+    def test_older_rejected(self):
+        """The pipeline writes the pose of an already-processed (older) frame;
+        it must not stomp a fresher receive-time pose."""
+        wm = self._wm()
+        wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), np.array([0, 0, 0, 1.0]), 101.0)
+        wm.update_robot_pose(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0, 1.0]), 100.0)
+        pose = wm.get_robot_pose()
+        assert pose["xyz"] == [4.0, 5.0, 6.0]
+        assert pose["timestamp"] == 101.0
+
+    def test_equal_timestamp_accepted(self):
+        """Same frame written twice (receiver then pipeline) is harmless."""
+        wm = self._wm()
+        wm.update_robot_pose(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0, 1.0]), 100.0)
+        wm.update_robot_pose(np.array([1.5, 2.5, 3.5]), np.array([0, 0, 0, 1.0]), 100.0)
+        assert wm.get_robot_pose()["xyz"] == [1.5, 2.5, 3.5]
+
+    def test_clear_resets_guard(self):
+        """After clear() (e.g. /reset between replay runs or demo trials),
+        older re-fed timestamps must be accepted again."""
+        wm = self._wm()
+        wm.update_robot_pose(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0, 1.0]), 1000.0)
+        wm.clear()
+        assert wm.get_robot_pose() is None
+        wm.update_robot_pose(np.array([7.0, 8.0, 9.0]), np.array([0, 0, 0, 1.0]), 5.0)
+        assert wm.get_robot_pose()["xyz"] == [7.0, 8.0, 9.0]
+
+
+# ─────────────────── WebSocketReceiver pose_sink ───────────────────
+
+
+def _identity_T_wc_col_major(t=(1.0, 2.0, 3.0)) -> list:
+    """4x4 identity-rotation pose with translation t, flattened column-major
+    (ARKit wire format)."""
+    m = np.eye(4, dtype=np.float64)
+    m[:3, 3] = t
+    return list(m.flatten(order="F"))
+
+
+def _binary_message(header: dict, rgb_bytes: bytes = b"", depth_bytes: bytes = b"") -> bytes:
+    hj = json.dumps(header).encode("utf-8")
+    return (
+        struct.pack("<I", len(hj)) + hj
+        + struct.pack("<I", len(rgb_bytes)) + rgb_bytes
+        + struct.pack("<I", len(depth_bytes)) + depth_bytes
+    )
+
+
+def _make_receiver(pose_sink, apply_camera_flip: bool = False) -> WebSocketReceiver:
+    return WebSocketReceiver(
+        ingest_queue=IngestQueue(maxsize=4),
+        require_tracking_normal=True,
+        keyframe_every_n=30,
+        nonkf_min_interval_s=0.5,
+        apply_camera_flip=apply_camera_flip,
+        pose_sink=pose_sink,
+    )
+
+
+def _header(unix_ts: float = 1234.5) -> dict:
+    return {
+        "T_wc": _identity_T_wc_col_major(),
+        "pose_format": "matrix4x4_col_major",
+        "tracking_state": "normal",
+        "unix_timestamp": unix_ts,
+        "timestamp_ns": 42,
+        "frame_id": 7,
+        "rgb_format": "jpeg",
+        "rgb_width": 2,
+        "rgb_height": 2,
+        "fx": 1.0, "fy": 1.0, "cx": 1.0, "cy": 1.0,
+    }
+
+
+class TestPoseSinkReceiveRate:
+    def test_sink_fires_on_throttled_frame(self):
+        """The key behavior: a frame the non-KF interval throttle skips
+        (parse returns None, no image decode) still delivers its pose."""
+        calls = []
+        rx = _make_receiver(lambda t, q, ts: calls.append((t.copy(), np.asarray(q).copy(), ts)))
+        # Arm the throttle: pretend frame 1 was just enqueued.
+        rx._frame_count = 1
+        rx._last_nonkf_enq_mono = time.monotonic()
+
+        pkt = rx._parse_binary_message(_binary_message(_header(unix_ts=999.25)))
+
+        assert pkt is None, "frame should be throttled (no FramePacket)"
+        assert len(calls) == 1, "pose sink must fire even for throttled frames"
+        t, q, ts = calls[0]
+        np.testing.assert_allclose(t, [1.0, 2.0, 3.0], atol=1e-6)
+        assert ts == 999.25
+
+    def test_sink_not_called_on_bad_tracking(self):
+        calls = []
+        rx = _make_receiver(lambda t, q, ts: calls.append(ts))
+        hdr = _header()
+        hdr["tracking_state"] = "limited"
+        pkt = rx._parse_binary_message(_binary_message(hdr))
+        assert pkt is None
+        assert calls == [], "garbage-tracking poses must not reach the sink"
+
+    def test_sink_pose_matches_framepacket_pose(self):
+        """The sink must deliver the same (post-convention) pose the
+        FramePacket carries — one convention for all consumers."""
+        calls = []
+        rx = _make_receiver(lambda t, q, ts: calls.append((np.asarray(t).copy(), np.asarray(q).copy())))
+        img = np.zeros((2, 2, 3), dtype=np.uint8)
+        _, jpeg = cv2.imencode(".jpg", img)
+        pkt = rx._parse_binary_message(
+            _binary_message(_header(), rgb_bytes=jpeg.tobytes())
+        )  # frame 1 → keyframe → fully parsed
+        assert pkt is not None
+        assert len(calls) == 1
+        t, q = calls[0]
+        np.testing.assert_allclose(t, pkt.pose.t_wc, atol=1e-6)
+        np.testing.assert_allclose(q, pkt.pose.q_wc_xyzw, atol=1e-6)
+
+    def test_flip_applied_to_sink_pose(self):
+        """With apply_camera_flip the sink sees the flipped (OpenCV) pose:
+        translation unchanged, rotation changed from identity."""
+        calls_flip, calls_noflip = [], []
+        for flip, calls in ((True, calls_flip), (False, calls_noflip)):
+            rx = _make_receiver(
+                lambda t, q, ts, c=calls: c.append((np.asarray(t).copy(), np.asarray(q).copy())),
+                apply_camera_flip=flip,
+            )
+            rx._frame_count = 1
+            rx._last_nonkf_enq_mono = time.monotonic()
+            assert rx._parse_binary_message(_binary_message(_header())) is None
+
+        (t_f, q_f), (t_n, q_n) = calls_flip[0], calls_noflip[0]
+        np.testing.assert_allclose(t_f, t_n, atol=1e-6)  # translation unaffected
+        assert not np.allclose(np.abs(q_f), np.abs(q_n), atol=1e-6), (
+            "flip must change the rotation quaternion"
+        )
+
+    def test_no_sink_is_safe(self):
+        rx = _make_receiver(pose_sink=None)
+        rx._frame_count = 1
+        rx._last_nonkf_enq_mono = time.monotonic()
+        assert rx._parse_binary_message(_binary_message(_header())) is None
+
+    def test_sink_error_does_not_break_parse(self):
+        def boom(t, q, ts):
+            raise RuntimeError("sink failure")
+
+        rx = _make_receiver(pose_sink=boom)
+        img = np.zeros((2, 2, 3), dtype=np.uint8)
+        _, jpeg = cv2.imencode(".jpg", img)
+        pkt = rx._parse_binary_message(_binary_message(_header(), rgb_bytes=jpeg.tobytes()))
+        assert pkt is not None, "a failing sink must not break frame parsing"

--- a/tests/test_pose_receive_time.py
+++ b/tests/test_pose_receive_time.py
@@ -61,6 +61,19 @@ class TestUpdateRobotPoseGuard:
         wm.update_robot_pose(np.array([1.5, 2.5, 3.5]), np.array([0, 0, 0, 1.0]), 100.0)
         assert wm.get_robot_pose()["xyz"] == [1.5, 2.5, 3.5]
 
+    def test_older_accepted_after_staleness_window(self):
+        """A sender clock stepping backward (new device / NTP) must not
+        freeze the pose forever: once the stored pose is older than the
+        guard window, an older-timestamped update is accepted."""
+        wm = self._wm()
+        wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), np.array([0, 0, 0, 1.0]), 1000.0)
+        # Simulate the stored pose aging past the guard window.
+        wm._latest_pose_arrival_mono -= wm._POSE_GUARD_WINDOW_S + 1.0
+        wm.update_robot_pose(np.array([7.0, 8.0, 9.0]), np.array([0, 0, 0, 1.0]), 10.0)
+        pose = wm.get_robot_pose()
+        assert pose["xyz"] == [7.0, 8.0, 9.0]
+        assert pose["timestamp"] == 10.0
+
     def test_clear_resets_guard(self):
         """After clear() (e.g. /reset between replay runs or demo trials),
         older re-fed timestamps must be accepted again."""


### PR DESCRIPTION
## Problem

`robot_pose` (the passthrough agents poll via `/stats` and the search endpoints) was only stored in `pipeline.py` **after full frame processing**, and sweep-gate-rejected frames return early — so consumers saw pose freshness at the **~1 Hz processing rate**, not the **~5 Hz** the iPhone actually streams. Worse, the receiver's keyframe/interval throttle skips frames *before* pose was even parsed.

For a closed-loop consumer (the Demo 2 RC-car agent re-aiming against live pose), 1 Hz means **20–30 cm of travel between corrections** vs a 40 cm arrival threshold; 5 Hz brings that to ~5 cm.

## Change

- **`websocket.py`** — hoist pose parse + ARKit→OpenCV convention flip above the keyframe/interval throttle; add an optional `pose_sink(t_wc, q_wc_xyzw, unix_ts)` callback fired for **every tracking-normal frame** (including throttled ones), carrying the exact post-flip pose the `FramePacket` carries. Missing/zero `unix_timestamp` is treated as absent (server wall-time substitute) so the sink and pipeline always share one clock.
- **`run.py`** — wire `pose_sink=wm.update_robot_pose` in live websocket mode.
- **`working_memory.py`** — `update_robot_pose` becomes a **guarded compare-and-set under the WM lock**: an update with a strictly older timestamp is ignored **while the stored pose is <2 s fresh** (process-monotonic arrival window). This blocks the slower pipeline write (~0.5–1 s behind) from stomping a fresher receive-time pose, while a sender clock stepping backward (new device, NTP, session restart) self-heals within the window instead of freezing the pose. `clear()` resets the stored pose so `/reset` + replay of older-timestamped recordings works.
- **Pipeline call site unchanged** — it remains the writer for the ZMQ and replay paths (its older-frame writes are now simply guarded out when the receiver is fresher).

## What did NOT change

- **No pose math / convention change** — the sink stores the same post-flip OpenCV-convention values the FramePacket carries (test-asserted).
- **No API change** — `/stats` and search endpoints simply serve fresher data. Response shape identical.
- Record-only, replay, ZMQ paths: unaffected (replayer's decoder-only receiver has no sink; pipeline write serves those paths as before).

## Tests

`tests/test_pose_receive_time.py` (12 new, all passing; +38 existing websocket/replay tests green):
- guard: newer/equal accepted, older rejected, **older accepted after staleness window**, `clear()` resets
- sink fires on **throttled** frames (the key behavior), not on bad-tracking frames
- sink pose == FramePacket pose (convention consistency), flip handling, sink-error isolation

Adversarially reviewed pre-PR (3-lens agent review); the review's major finding (guard could freeze pose across session restarts / clock skew) is fixed by the arrival-window bound in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)