### PR TITLE
security: bump postcss 8.5.15 -> 8.5.25 (sourceMappingURL path traversal)

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -277,6 +277,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -636,9 +670,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -676,9 +710,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -696,7 +730,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Closes the high-severity postcss alert on `main` ([Dependabot #4](https://github.com/calabi-inc/rtsm/security/dependabot/4)).

Lockfile-only change in `demo/`. Vite 8.0.16 declares `postcss: "^8.5.15"`, so 8.5.25 satisfies the existing range — no Vite bump, no `package.json` edit.

## Why

postcss `<= 8.5.22` auto-loads the path in a `/*# sourceMappingURL=... */` comment from disk on every `parse()` / `process()` call unless the caller explicitly passes `map: false`. In `lib/previous-map.js`:

```js
let map = this.annotation           // scraped straight out of the CSS text
if (file) map = join(dirname(file), map)
return this.loadFile(map)           // readFileSync
```

`path.join` normalizes `..` but does not confine the result to a base directory, so any `.map` file reachable by traversal — or any absolute path when `from` is unset — was read, and its `sourcesContent` folded into the emitted map.

| Advisory | Notes |
| --- | --- |
| [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) | High, CVSS 7.5 — path traversal via `sourceMappingURL` |
| [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) | Incomplete fix of GHSA-6g55-p6wh-862q when `from` is unset |

**8.5.18 is not sufficient**, despite being the version named in GHSA-r28c-9q8g-f849 — the follow-up incomplete-fix advisory raises the floor to **>= 8.5.23**.

## Relevance to this repo

`demo/src/main.ts:17` does `import 'uplot/dist/uPlot.min.css'`, so postcss genuinely processes a **third-party minified stylesheet from `node_modules`** — the build emits `dist/assets/index-*.css`. Minified CSS commonly carries a `sourceMappingURL` annotation, which is exactly this sink.

I checked: `uPlot.min.css` has no such annotation today, and no CSS anywhere under `node_modules` does. So there is no live trigger — but the code path is reachable, and any dependency bump that introduces an annotated stylesheet would activate it. Worth fixing rather than deferring.

## Verification

The upstream fix adds `isAbsolute`, `relative` and `sep` imports to `previous-map.js` and gates `loadFile` on three conditions: the path ends in `.map`, the CSS file's own path is known (an unset `from` is refused outright), and `relative(dirname(cssFile), path)` does not escape upward. The `unsafeMap` opt-out is off by default and Vite never sets it.

A probe planted a secret `.map` outside the CSS directory:

| Vector | 8.5.15 | 8.5.25 |
| --- | --- | --- |
| `sourceMappingURL=../../secret/stolen.map` (`from` set) | **LEAKED** | blocked |
| absolute path, `from` unset | **LEAKED** | blocked |
| control: legitimate sibling `ok.map` | loads | loads |

The vulnerable column is the negative control — it confirms the probe detects the flaw rather than passing vacuously. The third row confirms source maps still work, so this isn't just disabling the feature.

Also checked:

- `npm ci` from a wiped `node_modules` → exit 0
- `npm run build` → exit 0, CSS asset still emitted
- `npm audit` → **0 vulnerabilities**
- Dev server in-browser → WebGL 2.0 context, `getError()` 0, no console errors, and uPlot's `.u-axis.u-off { display: none }` rule still applies (confirming the third-party CSS pipeline is intact)

## Note on the diff size

Beyond postcss, the lockfile also moves `nanoid` 3.3.12 → 3.3.17 (postcss 8.5.25 requires `nanoid ^3.3.16`) and adds nested `@emnapi` entries under `@rolldown/binding-wasm32-wasi`.

The `@emnapi` entries are **not** related to postcss and **not** incidental churn from a local install — they were missing from the committed lockfile, and npm's resolver fills them in. I verified this by restoring the lockfile from `HEAD` and re-running `npm update postcss --package-lock-only` on a clean tree: the identical entries reappear. It's lockfile normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
