### PR TITLE
feat(core): frame-flow watchdog — /healthz can tell starved from hung from dead

### DIFF
--- a/rtsm/api/server.py
+++ b/rtsm/api/server.py
@@ -366,13 +366,14 @@ def create_app(
         Clears:
         - WorkingMemory (all objects, proto/confirmed)
         - ProximityIndex (spatial grid, via WM.clear())
+        - Vector store (FAISS LTM index — stale ids otherwise surface as
+          ghost objects in /search/semantic after reset)
         - SweepCache (sweep timestamps, camera snapshots)
         - FrameWindow (buffered RGB-D frames)
         - VisualizationServer registry (keyframes/point clouds)
 
         Does NOT clear:
         - FastSAM / CLIP models (expensive to reload)
-        - FAISS LTM vectors (preserves long-term memory)
         - Configuration
         """
         result: Dict[str, Any] = {
@@ -387,6 +388,17 @@ def create_app(
             result["cleared"]["working_memory"] = wm_result
         except Exception as e:
             result["cleared"]["working_memory"] = {"error": str(e)}
+
+        # Clear vector store — WM.clear() only clears the spatial index;
+        # the FAISS index is a separate store and must be reset with it.
+        if vectors is not None:
+            try:
+                if hasattr(vectors, "clear"):
+                    result["cleared"]["vector_store"] = vectors.clear()
+                else:
+                    result["cleared"]["vector_store"] = {"error": "vector store has no clear()"}
+            except Exception as e:
+                result["cleared"]["vector_store"] = {"error": str(e)}
 
         # Clear SweepCache
         if reset_components and reset_components.sweep_cache:
@@ -545,7 +557,9 @@ def create_app(
             entry: Dict[str, Any] = {
                 "id": oid,
                 "score": round(float(score), 4),
-                "confirmed": obj.confirmed if obj else True,
+                # A vector-store id with no WM object is stale (e.g. survived
+                # a partial clear) — never advertise it as confirmed.
+                "confirmed": obj.confirmed if obj else False,
                 "stability": round(float(obj.stability), 3) if obj else 0.0,
                 "xyz_world": obj.xyz_world.tolist() if obj and obj.xyz_world is not None else None,
             }

--- a/rtsm/api/server.py
+++ b/rtsm/api/server.py
@@ -35,6 +35,7 @@ def create_app(
     vis_broadcaster: Optional[Any] = None,
     vis_registry: Optional[Any] = None,
     static_dir: Optional[str] = None,
+    frame_flow_provider: Optional[Callable[[], Dict[str, Any]]] = None,
 ) -> FastAPI:
     """
     Build a FastAPI app exposing:
@@ -107,8 +108,23 @@ def create_app(
 
     # ---------------- Routes ----------------
     @app.get("/healthz")
-    def healthz() -> Dict[str, str]:
-        return {"status": "ok"}
+    def healthz() -> Dict[str, Any]:
+        # Additive shape: "status" stays "ok"/"degraded"; "frame_flow" and
+        # "reasons" appear only when a watchdog is wired (see
+        # rtsm/core/watchdog.py). Consumers reading only "status" are
+        # unaffected.
+        out: Dict[str, Any] = {"status": "ok"}
+        if frame_flow_provider is not None:
+            try:
+                ff = frame_flow_provider() or {}
+                out["frame_flow"] = ff
+                if ff.get("degraded"):
+                    out["status"] = "degraded"
+                    out["reasons"] = list(ff.get("reasons", []))
+            except Exception:
+                # Health endpoint must never fail because the watchdog did.
+                out["frame_flow"] = {"state": "unknown"}
+        return out
 
     @app.get("/readyz")
     def readyz() -> Dict[str, str]:

--- a/rtsm/cfg/rtsm.yaml
+++ b/rtsm/cfg/rtsm.yaml
@@ -318,6 +318,17 @@ api:
   host: "0.0.0.0"
   port: 8002
 
+# -------------------- Health --------------------
+# Frame-flow watchdog: classifies starved / hung / receiver_dead /
+# pose_degraded and surfaces it on /healthz. Observational only — it never
+# restarts anything. Not active in replay mode.
+health:
+  watchdog:
+    enable: true
+    poll_interval_s: 1.0            # How often the watchdog evaluates
+    starved_after_s: 5.0            # No client input for this long -> starved
+    hung_after_s: 10.0              # Frames waiting but pipeline loop silent -> hung
+
 # -------------------- MCP (Model Context Protocol) --------------------
 # Embedded MCP server exposes RTSM spatial memory as tools for AI agents.
 # Mounts on the existing API server at /mcp/ (SSE transport).

--- a/rtsm/core/pipeline.py
+++ b/rtsm/core/pipeline.py
@@ -21,6 +21,7 @@ from rtsm.core.ingest_gate import IngestGate
 from rtsm.stores.sweep_cache import SweepCache
 from rtsm.io.ingest_queue import IngestQueue
 from rtsm.core.datamodel import FramePacket
+from rtsm.core.watchdog import PipelineHeartbeat
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,8 @@ class Pipeline:
         self.sweep_cache = sweep_cache or SweepCache()
         self._seg_analytics = seg_analytics
         self._latency_analytics = latency_analytics
+        # Frame-flow heartbeat read by the watchdog (see rtsm/core/watchdog.py)
+        self.heartbeat = PipelineHeartbeat()
 
         # Periodic summary logger
         log_cfg = cfg.get("logging", {})
@@ -114,9 +117,11 @@ class Pipeline:
         This function is called repeatedly in the main loop to process incoming frames.
         """
         snap, pkt = self._get_snapshot_via_queue()
+        self.heartbeat.beat_step()
         if snap is None:
             time.sleep(0.01)
             return
+        self.heartbeat.beat_frame()
 
         # Ingest gate: accept keyframes unconditionally, gate non-KFs with policy
         accept = True

--- a/rtsm/core/watchdog.py
+++ b/rtsm/core/watchdog.py
@@ -1,0 +1,226 @@
+"""
+Frame-flow watchdog: distinguishes "pipeline alive but starved", "pipeline
+hung", and "receiver dead" — states that are indistinguishable from the
+outside today because /healthz has no frame-flow awareness.
+
+Purely observational: it never restarts anything. It classifies, exposes a
+status dict for /healthz, and logs state transitions.
+
+Components:
+- PipelineHeartbeat: two monotonic stamps the pipeline updates as it runs.
+- FrameFlowMonitor: pure classification logic (injectable clock, unit-testable).
+- Watchdog: daemon thread polling the monitor and logging transitions.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# States that mean "something is wrong". "waiting" (no client has ever
+# connected) and "ok" are healthy.
+DEGRADED_STATES = frozenset(
+    {"receiver_dead", "hung", "starved", "pose_degraded", "no_ingestible_input"}
+)
+
+
+class PipelineHeartbeat:
+    """Monotonic stamps updated by the pipeline loop.
+
+    beat_step() proves the loop is turning (stamped every run_one_step call,
+    including idle ones); beat_frame() proves frames are actually being
+    processed. Bare float assignment is atomic under the GIL, so readers on
+    other threads need no lock.
+    """
+
+    def __init__(self) -> None:
+        self.last_step_mono: Optional[float] = None
+        self.last_frame_mono: Optional[float] = None
+
+    def beat_step(self) -> None:
+        self.last_step_mono = time.monotonic()
+
+    def beat_frame(self) -> None:
+        self.last_frame_mono = time.monotonic()
+
+
+class FrameFlowMonitor:
+    """Classifies frame flow into one state per evaluation.
+
+    Sources are callables so the monitor stays decoupled and testable:
+    - heartbeat: PipelineHeartbeat (read-only)
+    - queue_size: () -> int, current ingest queue depth
+    - receiver_liveness: () -> {"alive": bool,
+                                "last_rx_mono": float|None,
+                                "last_enqueue_mono": float|None,
+                                "tracking_drops": int}
+
+    States, highest priority first:
+    - receiver_dead: receiver thread is gone; nothing will ever arrive.
+    - hung: frames are waiting (queue non-empty, or enqueued more recently
+      than the last pipeline step) but the loop stopped turning.
+    - starved: nothing has arrived from the client for starved_after_s
+      (stream died, phone slept, WiFi drop).
+    - pose_degraded: messages ARE arriving but nothing is ingestible and
+      tracking drops are climbing (ARKit tracking limited/lost).
+    - no_ingestible_input: messages arriving, nothing enqueued, no tracking
+      drops — e.g. text-only traffic or every frame throttled/failing parse.
+    - waiting: no client has ever connected since boot (normal at startup).
+    - ok: everything else.
+    """
+
+    def __init__(
+        self,
+        *,
+        heartbeat: PipelineHeartbeat,
+        queue_size: Callable[[], int],
+        receiver_liveness: Callable[[], Dict[str, Any]],
+        starved_after_s: float = 5.0,
+        hung_after_s: float = 10.0,
+        now_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._hb = heartbeat
+        self._queue_size = queue_size
+        self._receiver_liveness = receiver_liveness
+        self._starved_after_s = float(starved_after_s)
+        self._hung_after_s = float(hung_after_s)
+        self._now = now_fn
+        self._prev_tracking_drops: Optional[int] = None
+
+    @staticmethod
+    def _age(now: float, stamp: Optional[float]) -> Optional[float]:
+        return None if stamp is None else max(0.0, now - stamp)
+
+    def evaluate(self) -> Dict[str, Any]:
+        now = self._now()
+        recv = self._receiver_liveness() or {}
+        alive = bool(recv.get("alive", False))
+        rx_age = self._age(now, recv.get("last_rx_mono"))
+        enq_age = self._age(now, recv.get("last_enqueue_mono"))
+        step_age = self._age(now, self._hb.last_step_mono)
+        frame_age = self._age(now, self._hb.last_frame_mono)
+        drops = int(recv.get("tracking_drops", 0) or 0)
+        drops_delta = 0 if self._prev_tracking_drops is None else max(
+            0, drops - self._prev_tracking_drops
+        )
+        self._prev_tracking_drops = drops
+        try:
+            qsize = int(self._queue_size())
+        except Exception:
+            qsize = -1
+
+        state = "ok"
+        reasons = []
+        if not alive:
+            state = "receiver_dead"
+            reasons.append("receiver thread is not alive")
+        elif step_age is not None and step_age > self._hung_after_s and (
+            qsize > 0 or (enq_age is not None and enq_age < step_age)
+        ):
+            # Frames are waiting but the pipeline loop stopped turning.
+            state = "hung"
+            reasons.append(
+                f"pipeline loop silent for {step_age:.1f}s with frames waiting"
+            )
+        elif rx_age is None:
+            state = "waiting"
+        elif rx_age > self._starved_after_s:
+            state = "starved"
+            reasons.append(f"no input from client for {rx_age:.1f}s")
+        elif enq_age is not None and enq_age > self._starved_after_s:
+            if drops_delta > 0:
+                state = "pose_degraded"
+                reasons.append(
+                    f"input arriving but tracking-drops climbing "
+                    f"(+{drops_delta}); nothing enqueued for {enq_age:.1f}s"
+                )
+            else:
+                state = "no_ingestible_input"
+                reasons.append(
+                    f"input arriving but nothing enqueued for {enq_age:.1f}s"
+                )
+        elif enq_age is None and rx_age is not None:
+            # Client is talking but not one frame has ever been accepted.
+            if drops_delta > 0:
+                state = "pose_degraded"
+                reasons.append(
+                    f"client connected but no frame ever enqueued "
+                    f"(tracking-drops +{drops_delta})"
+                )
+
+        def _r(v: Optional[float]) -> Optional[float]:
+            return None if v is None else round(v, 2)
+
+        return {
+            "state": state,
+            "degraded": state in DEGRADED_STATES,
+            "reasons": reasons,
+            "receiver_alive": alive,
+            "last_input_age_s": _r(rx_age),
+            "last_ingest_age_s": _r(enq_age),
+            "last_step_age_s": _r(step_age),
+            "last_frame_age_s": _r(frame_age),
+            "ingest_queue_depth": qsize,
+            "tracking_drops": drops,
+        }
+
+
+class Watchdog(threading.Thread):
+    """Daemon thread: polls the monitor, caches the result for /healthz,
+    and logs state transitions (WARNING on degradation, INFO on recovery)."""
+
+    def __init__(
+        self,
+        *,
+        heartbeat: PipelineHeartbeat,
+        queue_size: Callable[[], int],
+        receiver_liveness: Callable[[], Dict[str, Any]],
+        starved_after_s: float = 5.0,
+        hung_after_s: float = 10.0,
+        poll_interval_s: float = 1.0,
+    ) -> None:
+        super().__init__(name="frame-flow-watchdog", daemon=True)
+        self._monitor = FrameFlowMonitor(
+            heartbeat=heartbeat,
+            queue_size=queue_size,
+            receiver_liveness=receiver_liveness,
+            starved_after_s=starved_after_s,
+            hung_after_s=hung_after_s,
+        )
+        self._poll_interval_s = max(0.1, float(poll_interval_s))
+        self._stop_event = threading.Event()
+        self._last: Dict[str, Any] = {
+            "state": "waiting",
+            "degraded": False,
+            "reasons": [],
+        }
+        self._last_logged_state = "waiting"
+
+    def status(self) -> Dict[str, Any]:
+        return dict(self._last)
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def run(self) -> None:
+        while not self._stop_event.wait(self._poll_interval_s):
+            try:
+                result = self._monitor.evaluate()
+            except Exception as e:  # never let the watchdog die silently
+                logger.warning(f"[watchdog] evaluation error: {e}")
+                continue
+            self._last = result
+            state = result["state"]
+            if state != self._last_logged_state:
+                msg = (
+                    f"[watchdog] frame flow: {self._last_logged_state} -> {state}"
+                    + (f" ({'; '.join(result['reasons'])})" if result["reasons"] else "")
+                )
+                if result["degraded"]:
+                    logger.warning(msg)
+                else:
+                    logger.info(msg)
+                self._last_logged_state = state

--- a/rtsm/io/websocket.py
+++ b/rtsm/io/websocket.py
@@ -250,6 +250,12 @@ class WebSocketReceiver:
         self._last_enq_ts_ns: Optional[int] = None
         self._active_session_id: Optional[str] = None
 
+        # Frame-flow liveness stamps (server-lifetime, read by the watchdog).
+        # Bare float/int assignment is atomic under the GIL — no lock needed.
+        self.last_rx_mono: Optional[float] = None
+        self.last_enqueue_mono: Optional[float] = None
+        self.tracking_drops: int = 0
+
         # Threading
         self._server_thread: Optional[threading.Thread] = None
         self._shutdown_event = asyncio.Event()
@@ -343,6 +349,7 @@ class WebSocketReceiver:
             while True:
                 msg = await ws.receive()
                 if msg["type"] == "websocket.receive":
+                    self.last_rx_mono = time.monotonic()
                     if "bytes" in msg and msg["bytes"]:
                         # Binary frame
                         frames_received += 1
@@ -367,6 +374,7 @@ class WebSocketReceiver:
                                 ok = self.ingest_q.put(pkt, block=False)
                                 if ok:
                                     frames_enqueued += 1
+                                    self.last_enqueue_mono = time.monotonic()
                                     self._last_enq_ts_ns = pkt.time.t_sensor_ns
                                     if not pkt.is_keyframe:
                                         self._last_nonkf_enq_mono = time.monotonic()
@@ -536,6 +544,7 @@ class WebSocketReceiver:
         # 5. Tracking state filter
         tracking_state = header.get("tracking_state", "not_available")
         if self._require_tracking_normal and tracking_state != "normal":
+            self.tracking_drops += 1
             if self._latency_analytics:
                 self._latency_analytics.record_tracking_drop()
             logger.info(
@@ -714,6 +723,16 @@ class WebSocketReceiver:
             name="websocket-receiver",
         )
         self._server_thread.start()
+
+    def liveness(self) -> dict:
+        """Frame-flow liveness snapshot for the watchdog."""
+        t = self._server_thread
+        return {
+            "alive": bool(t is not None and t.is_alive()),
+            "last_rx_mono": self.last_rx_mono,
+            "last_enqueue_mono": self.last_enqueue_mono,
+            "tracking_drops": self.tracking_drops,
+        }
 
     def stop(self) -> None:
         """Signal shutdown (best-effort; daemon thread exits with process)."""

--- a/rtsm/io/zeromq.py
+++ b/rtsm/io/zeromq.py
@@ -117,6 +117,12 @@ class ZeroMQSubscriber:
         self._last_nonkf_enq_mono: float = 0.0
         self._nonkf_min_interval_s: float = 0.5  # Max ~2 non-KF per second
 
+        # Frame-flow liveness stamps (read by the watchdog). The subscriber
+        # thread is created externally; run.py assigns it to self._thread.
+        self.last_rx_mono: Optional[float] = None
+        self.last_enqueue_mono: Optional[float] = None
+        self._thread: Optional[Any] = None
+
     def close(self):
         """Clean up ZMQ resources."""
         try:
@@ -508,6 +514,7 @@ class ZeroMQSubscriber:
             self._latency_analytics.sample_queue_depth(self.ingest_q.qsize())
         ok = self.ingest_q.put(fp, block=False)
         if ok:
+            self.last_enqueue_mono = time.monotonic()
             self._last_enq_ts_ns = ts_ns
             if not is_keyframe:
                 self._last_nonkf_enq_mono = now_mono
@@ -518,6 +525,16 @@ class ZeroMQSubscriber:
                 self._latency_analytics.record_queue_drop()
             frame_type = "keyframe" if is_keyframe else "non-KF"
             logger.warning(f"[zeromq] ingest queue full; dropping {frame_type}")
+
+    def liveness(self) -> dict:
+        """Frame-flow liveness snapshot for the watchdog."""
+        t = self._thread
+        return {
+            "alive": bool(t is not None and t.is_alive()),
+            "last_rx_mono": self.last_rx_mono,
+            "last_enqueue_mono": self.last_enqueue_mono,
+            "tracking_drops": 0,  # no tracking-state concept on the ZMQ path
+        }
 
     def run_forever(self) -> None:
         """Main loop: poll both sockets and dispatch messages."""
@@ -542,6 +559,7 @@ class ZeroMQSubscriber:
 
                 # Handle camera messages
                 if self.camera_sock in socks:
+                    self.last_rx_mono = time.monotonic()
                     parts = self.camera_sock.recv_multipart()
                     topic = parts[0].decode(errors="ignore")
                     if topic == "camera.rgbd":
@@ -549,6 +567,7 @@ class ZeroMQSubscriber:
 
                 # Handle RTABMap messages
                 if self.rtabmap_sock in socks:
+                    self.last_rx_mono = time.monotonic()
                     parts = self.rtabmap_sock.recv_multipart()
                     topic = parts[0].decode(errors="ignore")
                     if topic == "rtabmap.tracking_pose":

--- a/rtsm/run.py
+++ b/rtsm/run.py
@@ -290,6 +290,7 @@ def main():
             latency_analytics=latency_analytics,
         )
         t = threading.Thread(target=sub.run_forever, daemon=True)
+        sub._thread = t  # watchdog reads thread liveness via sub.liveness()
         t.start()
         logger.info(f"ZeroMQ dual-socket subscriber started (camera + RTABMap)")
         frame_window_for_reset = sub.fw
@@ -318,6 +319,31 @@ def main():
         seg_analytics=seg_analytics,
         latency_analytics=latency_analytics,
     )
+
+    # ---------------- Frame-flow watchdog (live receivers only) ----------------
+    # Distinguishes "starved" (input stopped), "hung" (frames waiting, loop
+    # silent), and "receiver_dead" — surfaced on /healthz. Replay mode skips it
+    # (a finished replay looks exactly like starvation).
+    watchdog = None
+    wd_cfg = cfg.get("health", {}).get("watchdog", {})
+    if bool(wd_cfg.get("enable", True)) and not args.replay:
+        receiver_liveness = None
+        if receiver_type == "websocket":
+            receiver_liveness = ws_receiver.liveness
+        elif receiver_type == "zeromq":
+            receiver_liveness = sub.liveness
+        if receiver_liveness is not None:
+            from rtsm.core.watchdog import Watchdog
+            watchdog = Watchdog(
+                heartbeat=pipe.heartbeat,
+                queue_size=ingest_q.qsize,
+                receiver_liveness=receiver_liveness,
+                starved_after_s=float(wd_cfg.get("starved_after_s", 5.0)),
+                hung_after_s=float(wd_cfg.get("hung_after_s", 10.0)),
+                poll_interval_s=float(wd_cfg.get("poll_interval_s", 1.0)),
+            )
+            watchdog.start()
+            logger.info("Frame-flow watchdog started")
 
     # ---------------- Start FastAPI control-plane ----------------
     api_cfg = cfg.get("api", {})
@@ -354,6 +380,7 @@ def main():
         vis_broadcaster=vis_broadcaster,
         vis_registry=vis_server_registry,
         static_dir=static_dir,
+        frame_flow_provider=watchdog.status if watchdog else None,
     )
     start_server(app, host=host, port=port)
     logger.info(f"FastAPI server started on http://{display_host}:{port}")

--- a/rtsm/stores/vectors/faiss_client.py
+++ b/rtsm/stores/vectors/faiss_client.py
@@ -14,6 +14,7 @@ class FaissClient:
     - upsert_batch(records)
     - search(emb, top_k)
     - delete(ids)
+    - clear()
     - save(path)
     - load(path)
     - close()
@@ -138,6 +139,27 @@ class FaissClient:
                 self.save(self.persistent_path)
             except Exception:
                 pass
+
+    def clear(self) -> Dict[str, int]:
+        """
+        Remove all vectors and reset the index (called on /reset).
+
+        Returns dict with count of what was cleared.
+        """
+        vec_count = len(self._row_to_id)
+        self._metadata.clear()
+        self._embeddings.clear()
+        self._row_to_id = []
+        self._id_to_row = {}
+        self._ensure_index()
+        self._index.reset()
+        # Persist the empty state, else a restart reloads the old vectors
+        if self.persistent_path:
+            try:
+                self.save(self.persistent_path)
+            except Exception:
+                pass
+        return {"vectors_cleared": vec_count}
 
     def save(self, path: str) -> None:
         if self._index is None:

--- a/tests/test_semantic_reset.py
+++ b/tests/test_semantic_reset.py
@@ -1,0 +1,167 @@
+"""
+Tests for /reset ↔ vector store coupling and semantic-search ghost handling.
+
+Covers:
+- FaissClient.clear() empties the index (search returns nothing) and reports
+  the cleared count.
+- POST /reset clears the FAISS vector store, so /search/semantic returns no
+  stale ids ("ghost" objects) from the previous map.
+- A vector-store id with no WorkingMemory object must report confirmed=False
+  (not True) — ghosts were crowding top-K slots advertising confirmed=True.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+from prometheus_client import CollectorRegistry
+
+from rtsm.api.server import create_app
+from rtsm.stores.vectors.faiss_client import FaissClient
+from rtsm.stores.working_memory import WorkingMemory, ObjectState
+
+DIM = 8
+
+
+def _unit(v: list[float]) -> np.ndarray:
+    a = np.asarray(v + [0.0] * (DIM - len(v)), dtype=np.float32)
+    return a / (np.linalg.norm(a) + 1e-12)
+
+
+# Query embedding and two stored embeddings with known cosine scores:
+# "obj_real" scores 1.0 against the query, "obj_ghost" ~0.707.
+QUERY_EMB = _unit([1.0])
+REAL_EMB = _unit([1.0])
+GHOST_EMB = _unit([1.0, 1.0])
+
+
+class FakeClipAdapter:
+    """Stands in for the CLIP adapter — returns a fixed query embedding."""
+
+    def encode_text(self, text: str) -> np.ndarray:
+        return QUERY_EMB
+
+
+def _make_object(oid: str, xyz: list[float], label: str = "object") -> ObjectState:
+    now = 1000.0
+    return ObjectState(
+        id=oid,
+        xyz_world=np.array(xyz, dtype=np.float32),
+        cov_world=np.array([0.01, 0.01, 0.01], dtype=np.float32),
+        emb_mean=np.zeros(512, dtype=np.float32),
+        emb_gallery=np.zeros((0, 512), dtype=np.float16),
+        view_bins={},
+        label_scores={label: 1.0},
+        label_primary=label,
+        stability=0.8,
+        hits=5,
+        confirmed=True,
+        created_mono=now,
+        created_wall_utc=now,
+        last_seen_mono=now,
+        last_seen_wall_utc=now,
+        last_seen_px=None,
+        last_upsert_wall_utc=0.0,
+        last_upsert_mono=0.0,
+        last_upsert_emb=None,
+        last_upsert_xyz=None,
+        image_crops=[],
+        last_update_frame_id=None,
+        _dim=512,
+    )
+
+
+def _make_vectors() -> FaissClient:
+    vc = FaissClient({"vectors": {"enable": True, "backend": "faiss", "dim": DIM}})
+    vc.upsert_batch([
+        {"object_id": "obj_real", "emb": REAL_EMB},
+        {"object_id": "obj_ghost", "emb": GHOST_EMB},
+    ])
+    return vc
+
+
+@pytest.fixture
+def client_and_vectors():
+    """TestClient whose vector store holds a real object and a ghost id
+    (present in FAISS but absent from WorkingMemory)."""
+    wm = WorkingMemory(cfg={})
+    obj = _make_object("obj_real", [1.0, 0.0, 1.0], "mug")
+    wm._map[obj.id] = obj
+    vectors = _make_vectors()
+    app = create_app(
+        working_memory=wm,
+        clip_adapter=FakeClipAdapter(),
+        vectors=vectors,
+        registry=CollectorRegistry(),
+    )
+    return TestClient(app), vectors
+
+
+# ─────────────────── FaissClient.clear ───────────────────
+
+
+class TestFaissClientClear:
+    def test_clear_empties_index_and_reports_count(self):
+        vc = _make_vectors()
+        assert len(vc.search(QUERY_EMB, top_k=5)) == 2
+        assert vc.clear() == {"vectors_cleared": 2}
+        assert vc.search(QUERY_EMB, top_k=5) == []
+
+    def test_clear_when_already_empty(self):
+        vc = FaissClient({"vectors": {"enable": True, "backend": "faiss", "dim": DIM}})
+        assert vc.clear() == {"vectors_cleared": 0}
+
+    def test_upsert_after_clear_works(self):
+        vc = _make_vectors()
+        vc.clear()
+        vc.upsert_batch([{"object_id": "obj_new", "emb": REAL_EMB}])
+        assert [oid for oid, _ in vc.search(QUERY_EMB, top_k=5)] == ["obj_new"]
+
+
+# ─────────────────── ghost entries in /search/semantic ───────────────────
+
+
+class TestSemanticGhostEntries:
+    def test_missing_wm_object_reports_unconfirmed(self, client_and_vectors):
+        """A FAISS id whose WM lookup fails is stale — it must not advertise
+        confirmed=True (ghosts were outranking real objects in top-K)."""
+        client, _ = client_and_vectors
+        resp = client.get("/search/semantic", params={"query": "mug"})
+        assert resp.status_code == 200
+        by_id = {r["id"]: r for r in resp.json()["results"]}
+        assert by_id["obj_ghost"]["confirmed"] is False
+        assert by_id["obj_ghost"]["stability"] == 0.0
+        assert by_id["obj_ghost"]["xyz_world"] is None
+        # The real object keeps its WM-backed fields
+        assert by_id["obj_real"]["confirmed"] is True
+        assert by_id["obj_real"]["xyz_world"] == [1.0, 0.0, 1.0]
+
+
+# ─────────────────── /reset clears the vector store ───────────────────
+
+
+class TestResetClearsVectors:
+    def test_reset_reports_vector_store_cleared(self, client_and_vectors):
+        client, _ = client_and_vectors
+        resp = client.post("/reset")
+        assert resp.status_code == 200
+        assert resp.json()["cleared"]["vector_store"] == {"vectors_cleared": 2}
+
+    def test_semantic_search_empty_after_reset(self, client_and_vectors):
+        """The live bug: after /reset, /search/semantic kept returning
+        old-map ids. The reset must leave no stale ids behind."""
+        client, _ = client_and_vectors
+        assert len(client.get("/search/semantic", params={"query": "mug"}).json()["results"]) == 2
+        client.post("/reset")
+        resp = client.get("/search/semantic", params={"query": "mug"})
+        assert resp.status_code == 200
+        assert resp.json()["results"] == []
+
+    def test_reset_without_vectors_configured(self):
+        """No vector store wired (e.g. semantic search disabled) — reset
+        must succeed and simply omit the vector_store entry."""
+        app = create_app(working_memory=WorkingMemory(cfg={}), registry=CollectorRegistry())
+        resp = TestClient(app).post("/reset")
+        assert resp.status_code == 200
+        assert "vector_store" not in resp.json()["cleared"]

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,258 @@
+"""Tests for the frame-flow watchdog (rtsm/core/watchdog.py) and its
+/healthz surfacing.
+
+The monitor is pure logic with injectable clock and sources, so every state
+is tested deterministically without threads or sleeps.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from prometheus_client import CollectorRegistry
+
+from rtsm.api.server import create_app
+from rtsm.core.watchdog import (
+    DEGRADED_STATES,
+    FrameFlowMonitor,
+    PipelineHeartbeat,
+    Watchdog,
+)
+
+
+class FakeReceiver:
+    def __init__(self):
+        self.alive = True
+        self.last_rx_mono = None
+        self.last_enqueue_mono = None
+        self.tracking_drops = 0
+
+    def liveness(self):
+        return {
+            "alive": self.alive,
+            "last_rx_mono": self.last_rx_mono,
+            "last_enqueue_mono": self.last_enqueue_mono,
+            "tracking_drops": self.tracking_drops,
+        }
+
+
+class Clock:
+    def __init__(self, t=1000.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+
+def make_monitor(recv, hb, clock, qsize=0, starved=5.0, hung=10.0):
+    return FrameFlowMonitor(
+        heartbeat=hb,
+        queue_size=lambda: qsize,
+        receiver_liveness=recv.liveness,
+        starved_after_s=starved,
+        hung_after_s=hung,
+        now_fn=clock,
+    )
+
+
+def test_waiting_before_any_client():
+    """Boot with no client ever connected -> waiting, not degraded."""
+    recv, hb, clock = FakeReceiver(), PipelineHeartbeat(), Clock()
+    hb.last_step_mono = clock.t - 0.5  # loop is turning
+    result = make_monitor(recv, hb, clock).evaluate()
+    assert result["state"] == "waiting"
+    assert result["degraded"] is False
+
+
+def test_ok_when_everything_fresh():
+    recv, hb, clock = FakeReceiver(), PipelineHeartbeat(), Clock()
+    recv.last_rx_mono = clock.t - 0.1
+    recv.last_enqueue_mono = clock.t - 0.5
+    hb.last_step_mono = clock.t - 0.2
+    hb.last_frame_mono = clock.t - 0.5
+    result = make_monitor(recv, hb, clock).evaluate()
+    assert result["state"] == "ok"
+    assert result["degraded"] is False
+    assert result["last_input_age_s"] == pytest.approx(0.1, abs=0.05)
+
+
+def test_starved_when_input_stops():
+    """Client connected once, then the stream died (phone slept, WiFi drop)."""
+    recv, hb, clock = FakeReceiver(), PipelineHeartbeat(), Clock()
+    recv.last_rx_mono = clock.t - 30.0
+    recv.last_enqueue_mono = clock.t - 30.0
+    hb.last_step_mono = clock.t - 0.2  # loop still turning (idle)
+    result = make_monitor(recv, hb, clock).evaluate()
+    assert result["state"] == "starved"
+    assert result["degraded"] is True
+    assert result["reasons"]
+
+
+def test_hung_when_frames_wait_but_loop_silent():
+    """Queue non-empty but the pipeline loop stopped turning -> hung."""
+    recv, hb, clock = FakeReceiver(), PipelineHeartbeat(), Clock()
+    recv.last_rx_mono = clock.t - 0.1
+    recv.last_enqueue_mono = clock.t - 0.1
+    hb.last_step_mono = clock.t - 60.0  # loop silent for a minute
+    result = make_monitor(recv, hb, clock, qsize=512).evaluate()
+    assert result["state"] == "hung"
+    assert result["degraded"] is True
+
+
+def test_hung_detected_via_recent_enqueue_even_with_empty_queue():
+    """Enqueue happened after the last step -> hung even if qsize reads 0."""
+    recv, hb, clock = FakeReceiver(), PipelineHeartbeat(), Clock()
+    recv.last_rx_mono = clock.t - 0.1
+    recv.last_enqueue_mono = clock.t - 1.0
+    hb.last_step_mono = clock.t - 60.0
+    result = make_monitor(recv, hb, clock, qsize=0).evaluate()
+    assert result["state"] == "hung"
+
+
+def test_receiver_dead_takes_priority():
+    recv, hb, clock = FakeReceiver(), PipelineHeartbeat(), Clock()
+    recv.alive = False
+    recv.last_rx_mono = clock.t - 0.1
+    hb.last_step_mono = clock.t - 0.1
+    result = make_monitor(recv, hb, clock).evaluate()
+    assert result["state"] == "receiver_dead"
+    assert result["degraded"] is True
+
+
+def test_pose_degraded_when_tracking_drops_climb():
+    """Messages arrive but nothing enqueues and tracking-drops climb
+    (ARKit tracking limited/lost) -> pose_degraded."""
+    recv, hb, clock = FakeReceiver(), PipelineHeartbeat(), Clock()
+    recv.last_rx_mono = clock.t - 0.1
+    recv.last_enqueue_mono = clock.t - 20.0
+    hb.last_step_mono = clock.t - 0.2
+    mon = make_monitor(recv, hb, clock)
+    mon.evaluate()  # baseline for the drops delta
+    recv.tracking_drops = 25
+    result = mon.evaluate()
+    assert result["state"] == "pose_degraded"
+    assert result["degraded"] is True
+
+
+def test_no_ingestible_input_without_tracking_drops():
+    recv, hb, clock = FakeReceiver(), PipelineHeartbeat(), Clock()
+    recv.last_rx_mono = clock.t - 0.1
+    recv.last_enqueue_mono = clock.t - 20.0
+    hb.last_step_mono = clock.t - 0.2
+    mon = make_monitor(recv, hb, clock)
+    mon.evaluate()
+    result = mon.evaluate()  # drops unchanged
+    assert result["state"] == "no_ingestible_input"
+    assert result["degraded"] is True
+
+
+def test_recovery_back_to_ok():
+    recv, hb, clock = FakeReceiver(), PipelineHeartbeat(), Clock()
+    recv.last_rx_mono = clock.t - 30.0
+    hb.last_step_mono = clock.t - 0.2
+    mon = make_monitor(recv, hb, clock)
+    assert mon.evaluate()["state"] == "starved"
+    # Stream resumes
+    clock.t += 10.0
+    recv.last_rx_mono = clock.t - 0.1
+    recv.last_enqueue_mono = clock.t - 0.2
+    hb.last_step_mono = clock.t - 0.1
+    result = mon.evaluate()
+    assert result["state"] == "ok"
+    assert result["degraded"] is False
+
+
+def test_degraded_states_registry_consistent():
+    assert "ok" not in DEGRADED_STATES
+    assert "waiting" not in DEGRADED_STATES
+
+
+def test_heartbeat_stamps_monotonic():
+    hb = PipelineHeartbeat()
+    assert hb.last_step_mono is None and hb.last_frame_mono is None
+    hb.beat_step()
+    hb.beat_frame()
+    now = time.monotonic()
+    assert hb.last_step_mono is not None and now - hb.last_step_mono < 1.0
+    assert hb.last_frame_mono is not None and now - hb.last_frame_mono < 1.0
+
+
+def test_watchdog_thread_status_and_transition_logging():
+    """Watchdog thread evaluates, caches status, and survives source errors."""
+    recv, hb = FakeReceiver(), PipelineHeartbeat()
+    recv.last_rx_mono = time.monotonic() - 30.0
+    hb.last_step_mono = time.monotonic()
+    wd = Watchdog(
+        heartbeat=hb,
+        queue_size=lambda: 0,
+        receiver_liveness=recv.liveness,
+        starved_after_s=5.0,
+        hung_after_s=10.0,
+        poll_interval_s=0.1,
+    )
+    wd.start()
+    try:
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            if wd.status().get("state") == "starved":
+                break
+            time.sleep(0.05)
+        assert wd.status()["state"] == "starved"
+        assert wd.status()["degraded"] is True
+    finally:
+        wd.stop()
+        wd.join(timeout=2.0)
+    assert not wd.is_alive()
+
+
+# ---------------- /healthz surfacing ----------------
+
+
+class _StubWM:
+    def stats(self):
+        return {"objects": 0, "confirmed": 0, "upserts_total": 0}
+
+
+def _client(provider=None):
+    app = create_app(
+        working_memory=_StubWM(),
+        registry=CollectorRegistry(),
+        frame_flow_provider=provider,
+    )
+    return TestClient(app)
+
+
+def test_healthz_unchanged_without_watchdog():
+    resp = _client().get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_healthz_reports_frame_flow_ok():
+    provider = lambda: {"state": "ok", "degraded": False, "reasons": []}
+    body = _client(provider).get("/healthz").json()
+    assert body["status"] == "ok"
+    assert body["frame_flow"]["state"] == "ok"
+    assert "reasons" not in body
+
+
+def test_healthz_degraded_with_reasons():
+    provider = lambda: {
+        "state": "starved",
+        "degraded": True,
+        "reasons": ["no input from client for 30.0s"],
+    }
+    body = _client(provider).get("/healthz").json()
+    assert body["status"] == "degraded"
+    assert body["frame_flow"]["state"] == "starved"
+    assert body["reasons"] == ["no input from client for 30.0s"]
+
+
+def test_healthz_survives_provider_exception():
+    def bad_provider():
+        raise RuntimeError("watchdog exploded")
+
+    body = _client(bad_provider).get("/healthz").json()
+    assert body["status"] == "ok"
+    assert body["frame_flow"] == {"state": "unknown"}


### PR DESCRIPTION
## Why

Today a stopped stream, a hung pipeline, and a dead receiver thread are **indistinguishable from the outside** — `/healthz` returns `{"status": "ok"}` in all three cases because it has no frame-flow awareness. This is L1 of the session-recovery design (investigated 2026-08-18): *know you're broken* before trying to recover from it.

## What

Purely observational — classifies and reports, never restarts anything.

- **`rtsm/core/watchdog.py`** (new): `PipelineHeartbeat` (two monotonic stamps in `run_one_step`), `FrameFlowMonitor` (pure classification logic, injectable clock, fully unit-tested), `Watchdog` (1 Hz daemon thread, caches status, logs state transitions).
- **States** (priority order): `receiver_dead` → `hung` (frames waiting but loop silent) → `starved` (no client input) → `pose_degraded` (input arriving, tracking-drops climbing, nothing enqueued) → `no_ingestible_input` → `waiting` (no client yet — healthy) → `ok`.
- **Receivers**: websocket + zeromq get `last_rx_mono` / `last_enqueue_mono` stamps, a tracking-drop counter (WS only), and a `liveness()` snapshot incl. thread-alive.
- **`/healthz`**: additively gains `frame_flow` + `reasons`; `status` flips to `degraded` on unhealthy flow. Without a watchdog wired the response is **byte-identical to before**; consumers reading only `status` are unaffected either way.
- **Config**: `health.watchdog` (`enable`, `poll_interval_s`, `starved_after_s`, `hung_after_s`). Not wired in replay mode — a finished replay is indistinguishable from starvation.

## Verification

- 16 new tests: every state, transitions/recovery, thread lifecycle, all four `/healthz` response shapes (incl. provider-exception safety).
- 58 pre-existing tests in touched areas still green (spatial_search, static_dir, websocket, semantic_reset, proximity, pose_receive_time, faiss_client). `test_ingest_gate.py`/`test_zmq.py` collect 0 pytest items (script-style, pre-existing).
- Live smoke test: real receiver classes report liveness; watchdog thread logged `waiting -> receiver_dead` with reason.

## Notes

- The demo2 branch (`feature/demo2-rc-car-agent`) carries its own `/healthz` additions (semantic-index lag); merging that branch later will produce a small, mechanical conflict in `healthz()` — both changes are additive and compose.
- Follow-ups from the same design doc (not in this PR): per-frame GPU-stage guards, pose-conversion-failure fix (identity-transform corruption), core-side teleport detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)