### PR TITLE
fix(core): drop frames whose pose fails conversion instead of corrupting the map

### DIFF
--- a/rtsm/core/association.py
+++ b/rtsm/core/association.py
@@ -115,6 +115,16 @@ class Associator:
             # if caller supplied world->cam missing, try 'pose_world_T_cam' or identity
             T_wc = getattr(snap, 'pose_world_T_cam', None)
             if T_wc is None:
+                # Identity fallback = camera-frame map. Legitimate only for
+                # pose-less sources (e.g. webcam demo); frames whose pose
+                # failed conversion are dropped upstream in the pipeline and
+                # never reach here. Log once so this is never silent.
+                if not getattr(self, '_warned_identity_world', False):
+                    self._warned_identity_world = True
+                    logger.warning(
+                        "[assoc] snapshot has no camera pose; using identity "
+                        "world transform (camera-frame map)"
+                    )
                 T_cw = np.eye(4, dtype=np.float32)
                 T_wc = np.eye(4, dtype=np.float32)
             else:

--- a/rtsm/core/pipeline.py
+++ b/rtsm/core/pipeline.py
@@ -72,6 +72,9 @@ class Pipeline:
         self.sweep_cache = sweep_cache or SweepCache()
         self._seg_analytics = seg_analytics
         self._latency_analytics = latency_analytics
+        # Frames dropped because a present pose failed matrix conversion
+        # (exposed via /stats; see _get_snapshot_via_queue)
+        self.pose_conversion_failures = 0
 
         # Periodic summary logger
         log_cfg = cfg.get("logging", {})
@@ -427,10 +430,18 @@ class Pipeline:
         intr = None
         if pkt.intr is not None:
             intr = {"fx": float(pkt.intr.fx), "fy": float(pkt.intr.fy), "cx": float(pkt.intr.cx), "cy": float(pkt.intr.cy)}
-        # Convert pose to T_cam_world if available
+        # Convert pose to T_cam_world if available.
+        # A frame with NO pose (pkt.pose is None — pose-less sources like the
+        # webcam demo) proceeds with pose_cam_T_world=None and keeps its
+        # camera-frame behavior. A pose that is PRESENT but fails conversion
+        # (raises, or produces a non-finite matrix) is corrupt input: the
+        # frame is DROPPED here. Letting it through would make the associator
+        # fall back to an identity world transform and insert objects at
+        # camera-frame coordinates into the world-frame map — silent
+        # corruption with no crash.
         T = None
-        try:
-            if pkt.pose is not None:
+        if pkt.pose is not None:
+            try:
                 T_wc = pkt.pose.T_wc()
                 # Note: ARKit→OpenCV camera flip is applied at ingestion
                 # (WebSocketReceiver) so T_wc is already in OpenCV convention.
@@ -448,8 +459,17 @@ class Pipeline:
                 T = np.eye(4, dtype=np.float32)
                 T[:3, :3] = R.T
                 T[:3, 3] = (-R.T @ t)
-        except Exception:
-            T = None
+                if not np.isfinite(T).all():
+                    raise ValueError("pose matrix has non-finite values")
+            except Exception as e:
+                self.pose_conversion_failures += 1
+                n = self.pose_conversion_failures
+                if n <= 3 or n % 100 == 0:
+                    logger.warning(
+                        f"[pipeline] dropping frame: pose present but conversion "
+                        f"failed (#{n}): {e}"
+                    )
+                return None, None
         return Snapshot(rgb=rgb, depth_m=depth_m, intrinsics=intr, pose_cam_T_world=T), pkt
 
     def _score_and_select(

--- a/rtsm/run.py
+++ b/rtsm/run.py
@@ -345,6 +345,7 @@ def main():
         vectors=vectors,
         extra_stats_provider=lambda: {
             "ingest_q": ingest_q.qsize(),
+            "pose_conversion_failures": pipe.pose_conversion_failures,
         },
         reset_components=reset_components,
         seg_analytics=seg_analytics,

--- a/tests/test_pose_conversion.py
+++ b/tests/test_pose_conversion.py
@@ -1,0 +1,134 @@
+"""Tests for the pose-conversion frame-drop fix.
+
+A frame whose pose is PRESENT but fails matrix conversion (raises, or
+produces non-finite values) must be dropped in _get_snapshot_via_queue —
+never handed downstream where the associator would substitute an identity
+world transform and write camera-frame coordinates into the world-frame map.
+
+A frame with NO pose at all (pose-less sources, e.g. the webcam demo) keeps
+its existing behavior: snapshot proceeds with pose_cam_T_world=None.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rtsm.core.datamodel import FramePacket, PoseStamped, TimeBundle
+from rtsm.core.pipeline import Pipeline
+from rtsm.io.ingest_queue import IngestQueue
+
+
+def _make_pipeline(q: IngestQueue) -> Pipeline:
+    return Pipeline(
+        cfg={},
+        segmenter=None,
+        clip=None,
+        working_mem=None,
+        proximity_index=None,
+        associator=None,
+        ingest_gate=None,
+        ingest_q=q,
+    )
+
+
+def _packet(pose) -> FramePacket:
+    return FramePacket(
+        rgb=np.zeros((4, 4, 3), dtype=np.uint8),
+        depth_m=None,
+        pose=pose,
+        intr=None,
+        is_keyframe=True,
+        time=TimeBundle(t_mono_s=0.0, t_wall_utc_s=0.0, t_sensor_ns=0),
+    )
+
+
+def _valid_pose() -> PoseStamped:
+    return PoseStamped(
+        stamp_ns=0,
+        frame_id="arkit",
+        t_wc=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+        q_wc_xyzw=np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),  # identity rotation
+    )
+
+
+class _RaisingPose:
+    """Duck-typed pose whose matrix conversion raises (corrupt input)."""
+
+    t_wc = np.array([0.0, 0.0, 0.0], dtype=np.float32)
+
+    def T_wc(self):
+        raise ValueError("corrupt pose payload")
+
+
+def test_valid_pose_converts_to_inverse_matrix():
+    q = IngestQueue()
+    pipe = _make_pipeline(q)
+    q.put(_packet(_valid_pose()))
+    snap, pkt = pipe._get_snapshot_via_queue()
+    assert snap is not None and pkt is not None
+    T = snap.pose_cam_T_world
+    assert T is not None and np.isfinite(T).all()
+    # Identity rotation: T_cam_world translation must be -t_wc
+    np.testing.assert_allclose(T[:3, 3], [-1.0, -2.0, -3.0], atol=1e-6)
+    assert pipe.pose_conversion_failures == 0
+
+
+def test_no_pose_keeps_cameraframe_behavior():
+    """pkt.pose=None (pose-less source) is NOT a failure: snapshot proceeds
+    with pose_cam_T_world=None, nothing is counted."""
+    q = IngestQueue()
+    pipe = _make_pipeline(q)
+    q.put(_packet(None))
+    snap, pkt = pipe._get_snapshot_via_queue()
+    assert snap is not None
+    assert snap.pose_cam_T_world is None
+    assert pipe.pose_conversion_failures == 0
+
+
+def test_raising_pose_drops_frame_and_counts():
+    q = IngestQueue()
+    pipe = _make_pipeline(q)
+    q.put(_packet(_RaisingPose()))
+    snap, pkt = pipe._get_snapshot_via_queue()
+    assert snap is None and pkt is None  # frame dropped, nothing downstream
+    assert pipe.pose_conversion_failures == 1
+
+
+def test_nonfinite_pose_drops_frame_and_counts():
+    """NaN-poisoned poses don't raise in T_wc() — they produce a NaN matrix.
+    The finiteness check must catch them."""
+    q = IngestQueue()
+    pipe = _make_pipeline(q)
+    bad = _valid_pose()
+    bad.t_wc = np.array([np.nan, 0.0, 0.0], dtype=np.float32)
+    q.put(_packet(bad))
+    snap, pkt = pipe._get_snapshot_via_queue()
+    assert snap is None and pkt is None
+    assert pipe.pose_conversion_failures == 1
+
+
+def test_counter_accumulates_and_good_frames_still_flow():
+    q = IngestQueue()
+    pipe = _make_pipeline(q)
+    for _ in range(3):
+        q.put(_packet(_RaisingPose()))
+    q.put(_packet(_valid_pose()))
+    results = [pipe._get_snapshot_via_queue() for _ in range(4)]
+    assert [snap is None for snap, _ in results] == [True, True, True, False]
+    assert pipe.pose_conversion_failures == 3
+
+
+def test_dropped_frame_never_reaches_memory(monkeypatch):
+    """End-to-end through run_one_step: a corrupt-pose frame must not touch
+    segmentation, association, or working memory."""
+    q = IngestQueue()
+    pipe = _make_pipeline(q)
+    touched = []
+    monkeypatch.setattr(
+        pipe, "segmenter",
+        type("Seg", (), {"segment": lambda self, *a, **k: touched.append("segment")})(),
+    )
+    q.put(_packet(_RaisingPose()))
+    pipe.run_one_step()
+    assert touched == []
+    assert pipe.pose_conversion_failures == 1

--- a/tests/test_pose_conversion.py
+++ b/tests/test_pose_conversion.py
@@ -11,7 +11,6 @@ its existing behavior: snapshot proceeds with pose_cam_T_world=None.
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from rtsm.core.datamodel import FramePacket, PoseStamped, TimeBundle
 from rtsm.core.pipeline import Pipeline


### PR DESCRIPTION
## Why

Category A from the session-recovery audit (2026-08-18) — the single worst silent-failure path found: a pose that parses but fails 4×4 matrix conversion became `T=None` via a bare `except Exception` (`_get_snapshot_via_queue`), and the Associator then substituted an **identity world transform**, inserting objects at camera-frame coordinates into the world-frame map. No crash, no log — silent corruption. NaN-poisoned poses were worse still: they don't raise, so they sailed through as NaN matrices.

## What

- **pipeline** (`_get_snapshot_via_queue`): a *present* pose that raises during conversion, or produces a non-finite matrix, now **drops the frame**, increments `pose_conversion_failures`, and logs a rate-limited WARNING (first 3, then every 100th). `pkt.pose=None` (pose-less sources, e.g. the webcam demo) keeps its existing camera-frame behavior — this fix only touches the corrupt-input path.
- **association**: the identity fallback — now reachable only by genuinely pose-less pipelines — logs once instead of never.
- **run**: `pose_conversion_failures` surfaced in `/stats`.

## Verification

- 6 new tests in `tests/test_pose_conversion.py`: valid-pose inverse math, no-pose passthrough, raising pose dropped+counted, **NaN pose dropped+counted** (the non-raising case), counter accumulation with good frames still flowing, and an end-to-end `run_one_step` proving a corrupt-pose frame never touches segmentation/memory.
- 58 pre-existing tests in touched areas re-run green (64 total with the new file).

## Notes

- Independent of PR #22 (branched from `main`); the two compose — a follow-up one-liner can fold this counter into the watchdog's `/healthz` block once both are merged.
- Realistic trigger is upstream NaN/corruption, essentially impossible from well-formed Calabi Lens output — so this does not cast doubt on existing E1 trial data; it hardens the ZMQ/RTAB-Map and future-source paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)