### PR TITLE
fix(stores): log failed post-reset FAISS save instead of swallowing it

### DIFF
--- a/rtsm/stores/vectors/faiss_client.py
+++ b/rtsm/stores/vectors/faiss_client.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 import faiss
+
+logger = logging.getLogger(__name__)
+
 
 class FaissClient:
     """
@@ -157,8 +161,16 @@ class FaissClient:
         if self.persistent_path:
             try:
                 self.save(self.persistent_path)
-            except Exception:
-                pass
+            except Exception as e:
+                # A failed post-reset save is dangerous, not ignorable: the
+                # pre-reset vectors are still on disk, so the next process
+                # restart resurrects them as ghost objects. Keep /reset
+                # non-fatal, but say so loudly.
+                logger.warning(
+                    f"[faiss] failed to persist cleared index after reset: {e} "
+                    f"-- on-disk store still holds pre-reset vectors; a restart "
+                    f"will resurrect them until a save succeeds"
+                )
         return {"vectors_cleared": vec_count}
 
     def save(self, path: str) -> None:


### PR DESCRIPTION
## Why

The `github-code-quality` bot flagged the empty `except Exception: pass` in `FaissClient.clear()` on PR #22. On inspection it isn't cosmetic — it hides a real failure mode (failure mode #4 from the Aug 18 persistence audit): `/reset` persists the emptied index to disk, and if that save fails, the pre-reset vectors remain on disk. The next process restart then **silently resurrects pre-reset objects as ghosts** in `/search/semantic`.

## What

One behavior-preserving change: `/reset` stays non-fatal, but the swallowed exception becomes a WARNING that names the consequence ("on-disk store still holds pre-reset vectors; a restart will resurrect them until a save succeeds"). Adds the module's missing logger.

## Verification

`tests/test_faiss_client.py` + `tests/test_semantic_reset.py` green.

## Notes

Independent micro-PR off `main`; no overlap with #22/#23. The remaining swallowed-exception sites from the audit are deliberate (shutdown paths, per-step `/reset` guards) or queued for the post-paper hygiene batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)