### PR TITLE
Add configuration profiles and a guide to threshold tuning

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,12 +1,90 @@
 # Configuration
 
-RTSM is configured via `config/rtsm.yaml`. This page covers the main settings grouped by section.
+RTSM ships its defaults in `rtsm/cfg/rtsm.yaml` and uses
+`rtsm/cfg/demo_config.yaml` for `rtsm demo`. A source checkout may also have a
+`config/` symlink. You can tune a small override file without editing the package.
+
+## Start with the symptom
+
+These commands work with core dependencies, without loading models or a GPU:
+
+From a source checkout, `python -m rtsm config ...` uses the checkout directly
+without requiring an updated console-script installation.
+
+```bash
+rtsm config explain --symptom pollution
+rtsm config explain --symptom duplicates
+rtsm config explain --demo --symptom missing
+```
+
+The guide shows the active backend's controls and their tradeoffs, and flags
+settings that currently have no effect. Choose from `missing`, `duplicates`,
+`pollution`, `latency`, and `search`, or omit `--symptom` for the full guide.
+
+For example, the actual mask-area cutoff is `filters.min_area_px`, not
+`staging.min_area_px`. The depth rejection fraction is
+`staging.depth_valid_min`, not `gates.min_depth_valid` or
+`filters.depth.valid_min_pct`. The `gates` and `masks` sections are not consumed
+by the current pipeline. The `segmentation.sam2` automatic-mask thresholds
+do not tune Grounded SAM2.
+
+The shipped main configuration includes the RC-car experiment's five-object
+vocabulary. Inspect it before evaluating on a different scene. The demo has a
+different vocabulary and confirmation policy. Neither is a universal reliability
+preset.
+
+## Repeatable tuning
+
+Save just the values you want to investigate in a file such as `room.yaml`:
+
+```yaml
+# An experiment, not a calibrated recommendation.
+staging:
+  depth_valid_min: 0.10
+```
+
+Then inspect, validate and replay the same profile:
+
+```bash
+rtsm config explain --profile room.yaml --symptom pollution
+rtsm config validate --profile room.yaml
+rtsm --replay recordings/my-room --profile room.yaml
+rtsm demo --profile room.yaml
+```
+
+Precedence is **base configuration → profiles in order → `--set` values in
+order**. Nested mappings merge; lists replace. Omitted settings retain their
+base values. Use `--profile` for a small patch; `--config` selects a complete
+base file. Both runners support these flags. The demo's `--port` and `--no-viz`
+flags take precedence over configuration values.
+
+```bash
+rtsm config show --profile room.yaml --set object.promote_hits=3 > trial.yaml
+rtsm --replay recordings/my-room --config trial.yaml
+```
+
+`show` writes valid YAML to stdout and advisories to stderr. Each resolved
+configuration has a SHA-256 fingerprint, also printed at runner startup.
+Keep the snapshot with the recording and evaluation results. The fingerprint
+identifies settings, not model weights, input data or code version.
+
+Profiles and `--set` reject unknown paths to catch typos. They accept settings
+from the shipped configurations, documented tuning controls, and any additional
+expert settings already declared in your complete `--config` file. Validation
+covers the documented tuning controls; it is not a complete schema or a check
+of hardware/model compatibility.
+
+Restart to apply a profile. There is no live-update API yet: component
+constructors cache some values. Change one suspected cause, compare against the
+same replay, and inspect wrong identities, misses, position error and stage
+latency. More confirmed objects alone does not establish better quality.
 
 ---
 
-## Minimal Configuration
+## Minimal setup profile
 
-A minimal config to get started — most defaults are sensible:
+For example, use the following as a `--profile` layered over the packaged
+defaults. Incoming per-frame intrinsics take precedence in the pipeline:
 
 ```yaml
 camera:

--- a/docs/plans/config-tuning.md
+++ b/docs/plans/config-tuning.md
@@ -1,0 +1,79 @@
+# Configuration tuning and the next product milestones
+
+## Problem and scope
+
+Threshold tuning is difficult because the configuration exposes many controls
+without making their effects clear. The current pipeline also mixes
+per-frame configuration reads with values cached by WorkingMemory, IngestGate,
+and model constructors. Applying a dictionary patch live is not an atomic
+pipeline update.
+
+The first implementation is a reproducible, explained tuning workflow:
+
+1. Preserve the existing main and demo defaults and their numerical behavior.
+2. Accept small YAML override profiles and explicit command-line overrides in
+   both runners. Show a resolved YAML snapshot that can be reused as a base.
+3. Provide a GPU-independent configuration command with a short, symptom-based
+   guide to active controls, validation of those controls, and warnings about
+   ineffective or conflicting settings. Include a configuration fingerprint.
+4. Test profile precedence, validation, inactive settings, snapshot round trips,
+   and dispatch without GPU dependencies. Do not change model dependencies.
+
+Architectural fit: this remains a plain dictionary at the component boundary,
+requires only the existing PyYAML core dependency, and leaves model adapters and
+pose math unchanged. Profiles are configuration files, not new model backends.
+No new numerical preset will be advertised as calibrated without replay data.
+
+## Implementation status
+
+Implemented on `feature/config-tuning`, based on demo2 commit
+`f7a0880ffe926bfddb0e95b8fe43b22931e62fce`:
+
+- Shared profile and command-line override loading for the main and demo runners.
+- GPU-independent `rtsm config explain/show/validate` commands, with a short
+  symptom guide and advisories about ineffective thresholds.
+- Resolved YAML snapshots, deterministic settings fingerprints, typo detection,
+  and validation of the documented tuning controls.
+- 36 focused tests passed, including unchanged packaged values, profile
+  precedence, snapshot round trips, and dispatch with runtime/model imports blocked.
+- Modified Python modules compiled successfully; Git whitespace checks passed.
+
+The existing `TestConfigLoader` tests in `tests/test_demo_components.py` could
+not be collected in the separate test environment because that module imports
+OpenCV. GPU/model execution and a full replay were not run. Focused tests cover
+the configuration behavior; model-output equivalence still needs replay validation.
+No model dependency declarations or CUDA/PyTorch installation were changed.
+
+## Follow-up: safe runtime changes
+
+After the useful tuning controls have been tested on representative recordings,
+introduce validated configuration revisions applied at a pipeline frame boundary.
+Each component must explicitly implement the supported update contract, or mark
+the setting as requiring restart. Record each revision with evaluation events;
+reject an entire invalid revision and retain the previous one.
+
+## Follow-up: cross-session memory
+
+First milestone: recover complete object records after process restart in an
+explicitly identified, unchanged map frame. Store authoritative metadata and
+embeddings transactionally; rebuild derived indexes and test interrupted writes.
+Cross-session means more than restarting FAISS. A new SLAM session can establish
+a different origin: spatial queries and object merging need verified alignment,
+or separate map namespaces. Do not silently combine coordinates from unrelated
+sessions. Test restart recovery, index rebuild, stale observations, and frame
+mismatch before claiming persistent spatial memory.
+
+## Follow-up: ONNX export/runtime
+
+Choose the target hardware and measure stage latency first. Select one adapter
+for an ONNX proof of concept, preserve its preprocessing/output contract, and
+compare its detections or embeddings against the current implementation. Measure
+warm and cold latency, peak memory, and end-to-end object retrieval quality on
+the same recordings. Provider fallback and unsupported operations must be
+observable. Export success alone is not a deployment acceptance criterion.
+
+## Acceptance limits
+
+This configuration change does not prove better object accuracy, provide live
+threshold updates, implement cross-session recovery, or add ONNX inference.
+Those are separate features with separate validation gates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ all = [
 ]
 
 [project.scripts]
-rtsm = "rtsm.run:main"
-rtsm-run = "rtsm.run:main"
+rtsm = "rtsm.cli:main"
+rtsm-run = "rtsm.cli:main"
 rtsm-mcp = "rtsm.io.mcp_server:main_sync"
 
 [build-system]

--- a/rtsm/__main__.py
+++ b/rtsm/__main__.py
@@ -1,5 +1,5 @@
 import logging
-from .run import main
+from .cli import main
 
 # Configure process-wide logging once at entrypoint
 logging.basicConfig(

--- a/rtsm/cfg/__init__.py
+++ b/rtsm/cfg/__init__.py
@@ -16,13 +16,23 @@ from __future__ import annotations
 
 from importlib import resources
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
+from copy import deepcopy
+import difflib
+import hashlib
+import json
+import math
 
 
-def cfg_path(name: str = "rtsm.yaml") -> Path:
+class ConfigError(ValueError):
+    """A configuration cannot be applied as written."""
+
+
+def cfg_path(name: str | Path = "rtsm.yaml") -> Path:
     """Resolve a config file path.
 
     Lookup order:
+      0. A Path object is an explicit file, with no fallback.
       1. importlib.resources (works for pip-installed package)
       2. CWD-relative ``config/<name>`` (legacy dev path via symlink)
 
@@ -36,6 +46,12 @@ def cfg_path(name: str = "rtsm.yaml") -> Path:
     Raises:
         FileNotFoundError: If the config file cannot be found.
     """
+    # Path objects are explicit user files; never fall back to package defaults.
+    if isinstance(name, Path):
+        if name.is_file():
+            return name.resolve()
+        raise FileNotFoundError(f"Config file not found: {name.resolve()}")
+
     # 1. Package resource (canonical — ships in wheel)
     pkg_path = resources.files("rtsm.cfg").joinpath(name)
     resolved = Path(str(pkg_path))
@@ -53,16 +69,142 @@ def cfg_path(name: str = "rtsm.yaml") -> Path:
     )
 
 
-def load_config(name: str = "rtsm.yaml") -> Dict[str, Any]:
+def load_config(
+    name: str | Path = "rtsm.yaml",
+    *,
+    profiles: Sequence[str | Path] = (),
+    set_values: Sequence[str] = (),
+) -> Dict[str, Any]:
     """Load and parse a YAML config file.
 
     Args:
-        name: Config filename (default ``"rtsm.yaml"``).
+        name: Packaged filename, or a Path for an explicit full base file.
+        profiles: Sparse YAML files, merged over the base in order.
+        set_values: Dotted path=YAML assignments, applied after all profiles.
 
     Returns:
         Parsed config dict.
     """
     import yaml
 
-    path = cfg_path(name)
-    return yaml.safe_load(path.read_text(encoding="utf-8"))
+    cfg = _read_yaml(cfg_path(name))
+    if not profiles and not set_values:
+        return cfg
+
+    # Profiles may use any shipped setting, a documented tuning control, or an
+    # expert setting already declared in the selected base config.
+    from .tuning import CONTROLS
+    known = _leaf_paths(_read_yaml(cfg_path("rtsm.yaml")))
+    known |= _leaf_paths(_read_yaml(cfg_path("demo_config.yaml")))
+    known |= _leaf_paths(cfg) | {control.path for control in CONTROLS}
+
+    for profile in profiles:
+        patch = _read_yaml(cfg_path(Path(profile)))
+        _check_override_keys(patch, known)
+        _merge(cfg, patch)
+    for assignment in set_values:
+        key, sep, raw = assignment.partition("=")
+        if not sep or not key or any(not part for part in key.split(".")):
+            raise ConfigError(f"Expected --set path=value, got {assignment!r}")
+        try:
+            value = yaml.safe_load(raw)
+        except yaml.YAMLError as exc:
+            raise ConfigError(f"Invalid YAML value for {key}: {exc}") from exc
+        _check_tree(value, key)
+        patch: dict = {}
+        node = patch
+        parts = key.split(".")
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+        node[parts[-1]] = value
+        _check_override_keys(patch, known)
+        _merge(cfg, patch)
+    return cfg
+
+
+def _read_yaml(path: Path) -> dict:
+    import yaml
+
+    class UniqueKeyLoader(yaml.SafeLoader):
+        pass
+
+    def construct_mapping(loader, node, deep=False):
+        result = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if not isinstance(key, str):
+                raise ConfigError(f"{path}: configuration keys must be strings")
+            if key in result:
+                raise ConfigError(f"{path}: duplicate key {key!r}")
+            result[key] = loader.construct_object(value_node, deep=deep)
+        return result
+
+    UniqueKeyLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping
+    )
+    try:
+        cfg = yaml.load(path.read_text(encoding="utf-8-sig"), Loader=UniqueKeyLoader)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"{path}: invalid YAML: {exc}") from exc
+    if not isinstance(cfg, dict):
+        raise ConfigError(f"{path}: expected a YAML mapping")
+    _check_tree(cfg, str(path))
+    return cfg
+
+
+def _check_tree(value: Any, path: str, ancestors: frozenset = frozenset()) -> None:
+    if isinstance(value, (dict, list)):
+        if id(value) in ancestors:
+            raise ConfigError(f"{path}: recursive YAML aliases are unsupported")
+        ancestors = ancestors | {id(value)}
+        items = value.items() if isinstance(value, dict) else enumerate(value)
+        for key, child in items:
+            if isinstance(value, dict) and not isinstance(key, str):
+                raise ConfigError(f"{path}: configuration keys must be strings")
+            _check_tree(child, f"{path}.{key}", ancestors)
+    elif not isinstance(value, (str, int, float, bool, type(None))):
+        raise ConfigError(f"{path}: unsupported value type {type(value).__name__}")
+    elif isinstance(value, float) and not math.isfinite(value):
+        raise ConfigError(f"{path}: value must be finite")
+
+
+def _leaf_paths(cfg: dict, prefix: str = "") -> set[str]:
+    paths = set()
+    for key, value in cfg.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            paths.update(_leaf_paths(value, path))
+        else:
+            paths.add(path)
+    return paths
+
+
+def _check_override_keys(patch: dict, known: set[str], prefix: str = "") -> None:
+    for key, value in patch.items():
+        path = f"{prefix}.{key}" if prefix else key
+        children = any(item.startswith(path + ".") for item in known)
+        if isinstance(value, dict) and children:
+            _check_override_keys(value, known, path)
+        elif path not in known or children:
+            matches = difflib.get_close_matches(path, known, n=1)
+            hint = f" Did you mean {matches[0]!r}?" if matches else ""
+            raise ConfigError(
+                f"Unknown or malformed override {path!r}.{hint} "
+                "Additional expert settings must be declared in the base --config file."
+            )
+
+
+def _merge(cfg: dict, patch: dict) -> None:
+    for key, value in patch.items():
+        if isinstance(value, dict):
+            if key in cfg and not isinstance(cfg[key], dict):
+                raise ConfigError(f"Cannot merge mapping into scalar setting {key!r}")
+            _merge(cfg.setdefault(key, {}), value)
+        else:
+            cfg[key] = deepcopy(value)
+
+
+def config_fingerprint(cfg: dict) -> str:
+    """Stable identity of the resolved configuration, not of model/data files."""
+    payload = json.dumps(cfg, sort_keys=True, ensure_ascii=True, allow_nan=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/rtsm/cfg/__main__.py
+++ b/rtsm/cfg/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/rtsm/cfg/cli.py
+++ b/rtsm/cfg/cli.py
@@ -1,0 +1,54 @@
+"""Configuration commands that require no GPU or model downloads."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from . import ConfigError, config_fingerprint, load_config
+from .tuning import SYMPTOMS, explain_tuning, validate_tuning
+
+
+def add_config_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--config", type=Path, help="Explicit base YAML file (otherwise use the runner's packaged default)")
+    parser.add_argument("--profile", action="append", default=[], type=Path,
+                        help="Sparse YAML overrides; repeat to layer profiles in order")
+    parser.add_argument("--set", dest="config_sets", action="append", default=[], metavar="PATH=VALUE",
+                        help="Override a setting with a YAML value; applied after profiles")
+
+
+def config_from_args(args, default: str = "rtsm.yaml") -> dict:
+    cfg = load_config(args.config if args.config is not None else default,
+                      profiles=args.profile, set_values=args.config_sets)
+    validate_tuning(cfg)
+    return cfg
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="rtsm config",
+                                     description="Explain and reproduce threshold tuning without loading models")
+    parser.add_argument("action", choices=("explain", "show", "validate"), nargs="?", default="explain")
+    parser.add_argument("--demo", action="store_true", help="Use packaged demo defaults as the base")
+    parser.add_argument("--symptom", choices=tuple(SYMPTOMS), help="Focus the tuning explanation")
+    add_config_arguments(parser)
+    args = parser.parse_args(argv)
+    if args.demo and args.config is not None:
+        parser.error("--demo and --config select different bases; choose one")
+    try:
+        cfg = config_from_args(args, "demo_config.yaml" if args.demo else "rtsm.yaml")
+        if args.action == "explain":
+            print(explain_tuning(cfg, args.symptom))
+        elif args.action == "show":
+            import yaml
+            # stdout remains valid YAML for redirection and round-trip loading.
+            print(f"# Config SHA-256: {config_fingerprint(cfg)}")
+            print(yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True), end="")
+        else:
+            print(f"Tuning controls valid. Config SHA-256: {config_fingerprint(cfg)}")
+            print("Validation covers documented tuning controls, not every expert setting.")
+        if args.action != "explain":
+            for warning in validate_tuning(cfg):
+                print(f"Advisory: {warning}", file=sys.stderr)
+    except (ConfigError, OSError) as exc:
+        parser.error(str(exc))

--- a/rtsm/cfg/tuning.py
+++ b/rtsm/cfg/tuning.py
@@ -1,0 +1,192 @@
+"""A small, code-traced tuning surface; no model imports or calibrated presets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+from . import ConfigError, config_fingerprint
+
+
+@dataclass(frozen=True)
+class Control:
+    path: str
+    default: float | int | None
+    symptoms: tuple[str, ...]
+    explanation: str
+    minimum: float = 0
+    maximum: float | None = None
+    integer: bool = False
+    backends: tuple[str, ...] = ()
+
+
+# Defaults trace to segmentation/__init__.py, utils/mask_staging.py,
+# core/pipeline.py, core/association.py, stores/working_memory.py and run.py.
+# None denotes a required setting whose consumer has no fallback.
+CONTROLS = (
+    Control("segmentation.grounded_sam2.box_threshold", .25, ("missing", "pollution"),
+            "Raise to reject weaker detections; lower may recover objects and add false detections.",
+            maximum=1, backends=("grounded_sam2",)),
+    Control("segmentation.grounded_sam2.text_threshold", .2, ("missing",),
+            "Controls text-token matching. Check the prompted vocabulary before lowering this.",
+            maximum=1, backends=("grounded_sam2",)),
+    Control("segmentation.fastsam.conf", .4, ("missing", "pollution"),
+            "Raise to reject weaker mask proposals; inspect missed objects on the same replay.",
+            maximum=1, backends=("fastsam", "dual")),
+    Control("segmentation.yoloe.conf", .25, ("missing", "pollution"),
+            "Raise to reject weaker detections; lower trades precision for recall.",
+            maximum=1, backends=("yoloe", "dual")),
+    Control("segmentation.sam2.pred_iou_thresh", .7, ("missing", "pollution"),
+            "Auto-mask quality cutoff; this is not used by the grounded_sam2 factory.",
+            maximum=1, backends=("sam2",)),
+    Control("filters.min_area_px", None, ("missing",),
+            "Actual mask area cutoff in pixels. Lower for small objects; fragments may increase.",
+            minimum=1, integer=True),
+    Control("staging.depth_valid_min", .15, ("pollution",),
+            "Rejects masks with too little valid depth after erosion. Higher can reject reflective objects.",
+            maximum=1),
+    Control("staging.centroid_min_valid", .25, ("pollution",),
+            "Minimum valid-depth fraction before a 3D centroid is computed.",
+            maximum=1),
+    Control("filters.depth.sigma_max_m", .35, ("pollution",),
+            "Despite the name, compares depth quantile spread in metres, not a calibrated standard deviation.",
+            minimum=.000001),
+    Control("staging.topk_preclip", 5, ("missing", "latency"),
+            "Caps candidates encoded by CLIP after scoring/dedup. Lower saves that work, not segmentation work.",
+            minimum=1, integer=True),
+    Control("assoc.gate_dist_base_m", .20, ("duplicates",),
+            "Cross-frame distance gate in metres. Wider may reduce splits and merge neighbouring objects.",
+            minimum=.000001),
+    Control("assoc.gate_reproj_px", 30., ("duplicates",),
+            "Cross-frame reprojection gate in pixels. Inspect pose/depth errors before widening.",
+            minimum=.000001),
+    Control("assoc.cos_min", .95, ("duplicates",),
+            "Cross-frame embedding similarity floor. Higher may separate objects and split identities.",
+            maximum=1),
+    Control("object.promote_hits", 2, ("missing", "pollution"),
+            "Observations required for confirmation; repeated false detections can still pass.",
+            minimum=1, integer=True),
+    Control("object.stability_promote", .50, ("missing", "pollution"),
+            "Confirmation score cutoff. This score is not a probability of correctness.",
+            maximum=1),
+    Control("object.require_view_bins", 2, ("search",),
+            "View diversity required for confirmation. A stationary camera may only produce one bin.",
+            minimum=1, integer=True),
+    Control("ltm.ltm_min_view_bins", 2, ("search",),
+            "View diversity required for vector upsert; defaults to object.require_view_bins.",
+            minimum=1, integer=True),
+    Control("io.websocket.nonkf_min_interval_s", .5, ("latency",),
+            "Receiver throttle for non-keyframes. Higher reduces observations; keyframes follow a separate path."),
+)
+
+SYMPTOMS = {
+    "missing": "Missing objects: check model vocabulary and filter drop reasons first.",
+    "duplicates": "Duplicate identities: distinguish same-frame mask duplicates from cross-frame splits.",
+    "pollution": "Wrong objects or positions: inspect masks, depth and pose before loosening thresholds.",
+    "latency": "Slow processing: measure stage latency before sacrificing recall.",
+    "search": "Confirmed but absent from search: inspect vector upsert eligibility.",
+}
+
+
+def _get(cfg: dict, path: str, default=None):
+    node = cfg
+    for part in path.split("."):
+        if not isinstance(node, dict):
+            raise ConfigError(f"{path}: parent section must be a mapping")
+        if part not in node:
+            return default
+        node = node[part]
+    return node
+
+
+def _value(cfg: dict, control: Control):
+    default = control.default
+    if control.path == "ltm.ltm_min_view_bins":
+        default = _get(cfg, "object.require_view_bins", 2)
+    return _get(cfg, control.path, default)
+
+
+def active_controls(cfg: dict):
+    backend = _get(cfg, "segmentation.backend", "fastsam")
+    for control in CONTROLS:
+        if control.backends and backend not in control.backends:
+            continue
+        if control.path == "assoc.cos_min" and not _get(cfg, "assoc.use_embeddings", True):
+            continue
+        if control.path.startswith("io.websocket.") and _get(cfg, "io.receiver", "zeromq") != "websocket":
+            continue
+        yield control
+
+
+def validate_tuning(cfg: dict) -> list[str]:
+    """Check the documented controls and return advisories, not accuracy claims.
+
+    This is deliberately not a complete schema for every expert setting.
+    """
+    backend = _get(cfg, "segmentation.backend", "fastsam")
+    if backend not in ("grounded_sam2", "sam2", "fastsam", "yoloe", "dual"):
+        raise ConfigError(f"Unknown segmentation.backend: {backend!r}")
+    for control in active_controls(cfg):
+        value = _value(cfg, control)
+        valid = type(value) in (int, float) and math.isfinite(value)
+        if control.integer:
+            valid = valid and type(value) is int
+        if not valid or value < control.minimum or (
+            control.maximum is not None and value > control.maximum
+        ):
+            kind = "integer" if control.integer else "number"
+            upper = f" and <= {control.maximum}" if control.maximum is not None else ""
+            raise ConfigError(
+                f"{control.path}: expected a finite {kind} >= {control.minimum}{upper}; got {value!r}"
+            )
+
+    warnings = []
+    ineffective = (
+        ("gates", "The gates section is not consumed by the current pipeline."),
+        ("masks", "The masks section is not consumed by the current pipeline."),
+        ("staging.min_area_px", "staging.min_area_px has no effect; use filters.min_area_px."),
+        ("filters.depth.valid_min_pct", "filters.depth.valid_min_pct has no effect; use staging.depth_valid_min."),
+    )
+    for path, message in ineffective:
+        if _get(cfg, path) is not None:
+            warnings.append(message)
+    if _get(cfg, "staging.centroid_min_valid", .25) > _get(cfg, "staging.depth_valid_min", .15):
+        warnings.append("Some masks can pass the depth filter but lack enough valid depth for a 3D centroid.")
+    required_bins = _get(cfg, "object.require_view_bins", 2)
+    if _get(cfg, "ltm.ltm_min_view_bins", required_bins) > required_bins:
+        warnings.append("LTM requires more view bins than confirmation; some confirmed objects may be absent from semantic search.")
+    if not _get(cfg, "vectors.enable", True):
+        warnings.append("Vector storage is disabled; semantic search will be unavailable.")
+    if backend == "grounded_sam2":
+        for key in ("pred_iou_thresh", "stability_score_thresh", "points_per_side"):
+            if _get(cfg, f"segmentation.sam2.{key}") is not None:
+                warnings.append("SAM2 automatic-mask thresholds/grid settings do not configure grounded_sam2; only sam2.model_id supplies its fallback model.")
+                break
+    return warnings
+
+
+def explain_tuning(cfg: dict, symptom: str | None = None) -> str:
+    warnings = validate_tuning(cfg)
+    lines = [
+        f"Config SHA-256: {config_fingerprint(cfg)}",
+        f"Segmentation backend: {_get(cfg, 'segmentation.backend', 'fastsam')}",
+        "Restart after applying changes. This command does not update a running process.",
+        "Values are existing settings or component defaults, not calibrated recommendations.",
+    ]
+    if _get(cfg, "segmentation.backend") == "grounded_sam2":
+        vocab = _get(cfg, "segmentation.grounded_sam2.vocab")
+        lines.append(f"Detection vocabulary: {vocab if vocab is not None else 'backend default'}")
+    controls = list(active_controls(cfg))
+    for name in ([symptom] if symptom else SYMPTOMS):
+        lines.extend(("", SYMPTOMS[name]))
+        for control in controls:
+            if name in control.symptoms:
+                source = " [component default]" if _get(cfg, control.path) is None else ""
+                lines.append(f"  {control.path} = {_value(cfg, control)}{source}")
+                lines.append(f"    {control.explanation}")
+    if warnings:
+        lines.extend(("", "Configuration advisories:"))
+        lines.extend(f"  - {warning}" for warning in warnings)
+    lines.extend(("", "Change one cause at a time; replay the same data and compare wrong identities,",
+                  "missing objects, position errors, and stage latency. Object count alone is not quality."))
+    return "\n".join(lines)

--- a/rtsm/cli.py
+++ b/rtsm/cli.py
@@ -1,0 +1,12 @@
+"""Dispatch lightweight commands before importing the runtime and GPU stack."""
+
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == "config":
+        from rtsm.cfg.cli import main as config_main
+        config_main(sys.argv[2:])
+    else:
+        from rtsm.run import main as run_main
+        run_main()

--- a/rtsm/demo.py
+++ b/rtsm/demo.py
@@ -70,8 +70,21 @@ def run_demo(argv: list[str] | None = None) -> None:
         description="Run RTSM demo with pre-recorded data",
     )
     parser.add_argument("--no-viz", action="store_true", help="Skip visualization server")
-    parser.add_argument("--port", type=int, default=8002, help="API/UI port (default: 8002)")
+    parser.add_argument("--port", type=int, default=None, help="API/UI port (default: configured api.port, normally 8002)")
+    from rtsm.cfg import ConfigError, cfg_path, config_fingerprint
+    from rtsm.cfg.cli import add_config_arguments, config_from_args
+    from rtsm.cfg.tuning import validate_tuning
+    add_config_arguments(parser)
     args = parser.parse_args(argv or [])
+    try:
+        cfg = config_from_args(args, "demo_config.yaml")
+    except (ConfigError, OSError) as exc:
+        parser.error(str(exc))
+    if args.port is not None:
+        cfg.setdefault("api", {})["port"] = args.port
+    if args.no_viz:
+        cfg.setdefault("visualization", {})["enable"] = False
+    args.port = int(cfg.get("api", {}).get("port", 8002))
 
     print("=" * 60)
     print("  RTSM Demo - Real-Time Spatio-Semantic Memory")
@@ -99,13 +112,14 @@ def run_demo(argv: list[str] | None = None) -> None:
 
     # ── Load config ──
     print("  [2/5] Loading configuration...")
-    from rtsm.cfg import load_config, cfg_path
-    cfg = load_config("demo_config.yaml")
-    print(f"        Config: {cfg_path('demo_config.yaml')}")
+    print(f"        Config: {cfg_path(args.config if args.config is not None else 'demo_config.yaml')}")
+    print(f"        Config SHA-256: {config_fingerprint(cfg)}")
+    for advisory in validate_tuning(cfg):
+        logger.warning("Configuration: %s", advisory)
     print(f"        Backend: {cfg['segmentation']['backend']}")
 
     # ── Load models ──
-    print("  [3/5] Loading segmentation model (grounded_sam2)...")
+    print(f"  [3/5] Loading segmentation model ({cfg['segmentation']['backend']})...")
     print("        (Downloads ~1GB from HuggingFace on first run)")
     from rtsm.models.segmentation import get_segmenter
     segmenter = get_segmenter(cfg)

--- a/rtsm/run.py
+++ b/rtsm/run.py
@@ -31,7 +31,9 @@ from rtsm.utils.net import print_server_addresses, get_local_ipv4_addresses
 from rtsm.utils.static_dir import find_static_dir
 from rtsm.stores.sweep_policy import SweepPolicy
 from rtsm.api.server import create_app, start_server, ResetComponents
-from rtsm.cfg import load_config, cfg_path
+from rtsm.cfg import ConfigError, cfg_path, config_fingerprint
+from rtsm.cfg.cli import add_config_arguments, config_from_args
+from rtsm.cfg.tuning import validate_tuning
 
 import argparse
 import sys
@@ -68,7 +70,12 @@ def main():
                         help="Replay speed multiplier (<1 = slower, e.g. 0.5 = half speed)")
     parser.add_argument("--record-only", action="store_true",
                         help="Record without running pipeline (no GPU needed)")
+    add_config_arguments(parser)
     args = parser.parse_args()
+    try:
+        cfg = config_from_args(args)
+    except (ConfigError, OSError) as exc:
+        parser.error(str(exc))
 
     print("=" * 60)
     print("  RTSM - Real-Time Spatio-Semantic Memory")
@@ -81,8 +88,11 @@ def main():
         print("For CUDA support, add:  --extra-index-url https://download.pytorch.org/whl/cu128")
         return
 
-    cfg = load_config("rtsm.yaml")
-    logger.info(f"Configuration loaded from {cfg_path('rtsm.yaml')}")
+    logger.info("Configuration loaded: %s (SHA-256 %s)",
+                cfg_path(args.config if args.config is not None else "rtsm.yaml"),
+                config_fingerprint(cfg))
+    for advisory in validate_tuning(cfg):
+        logger.warning("Configuration: %s", advisory)
 
     # ── Record-only mode: skip all heavy init, just record raw WebSocket ──
     if args.record and args.record_only:

--- a/tests/test_config_tuning.py
+++ b/tests/test_config_tuning.py
@@ -134,7 +134,9 @@ def test_guide_exposes_effective_controls_and_inactive_ones():
     assert "gates section is not consumed" in report
     assert "segmentation.fastsam.conf =" not in report
     assert "not a probability of correctness" in report
-    assert "teddy bear" in report
+    assert "Detection vocabulary:" in report
+    custom = load_config(set_values=["segmentation.grounded_sam2.vocab=[teddy bear]"])
+    assert "Detection vocabulary: ['teddy bear']" in explain_tuning(custom, "pollution")
 
 
 def test_upsert_mismatch_is_advisory_not_unsupported_constraint():

--- a/tests/test_config_tuning.py
+++ b/tests/test_config_tuning.py
@@ -1,0 +1,194 @@
+"""Configuration safety and reproducibility, independent of GPU dependencies."""
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+from rtsm.cfg import ConfigError, cfg_path, config_fingerprint, load_config
+from rtsm.cfg.cli import add_config_arguments, config_from_args, main
+from rtsm.cfg.tuning import explain_tuning, validate_tuning
+
+
+@pytest.mark.parametrize("name", ["rtsm.yaml", "demo_config.yaml"])
+def test_default_values_are_unchanged(name):
+    assert load_config(name) == yaml.safe_load(cfg_path(name).read_text(encoding="utf-8"))
+    validate_tuning(load_config(name))
+
+
+def test_explicit_base_does_not_silently_fall_back(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        load_config(Path("rtsm.yaml"))
+    Path("rtsm.yaml").write_text("object:\n  promote_hits: 7\n", encoding="utf-8")
+    assert load_config(Path("rtsm.yaml"))["object"]["promote_hits"] == 7
+    assert load_config("rtsm.yaml")["object"]["promote_hits"] == 2
+    assert cfg_path("clip/vocab.yaml").is_file()
+
+
+def test_profiles_then_cli_preserve_unrelated_values_and_replace_lists(tmp_path):
+    room = tmp_path / "room.yaml"
+    trial = tmp_path / "trial.yaml"
+    room.write_text("object:\n  promote_hits: 4\nsegmentation:\n  grounded_sam2:\n    vocab: [cup, book]\n", encoding="utf-8")
+    trial.write_text("object:\n  promote_hits: 5\n", encoding="utf-8")
+    baseline = load_config()
+    cfg = load_config(profiles=[room, trial], set_values=["object.promote_hits=6"])
+    assert cfg["object"]["promote_hits"] == 6
+    assert cfg["segmentation"]["grounded_sam2"]["vocab"] == ["cup", "book"]
+    assert cfg["object"]["stability_promote"] == baseline["object"]["stability_promote"]
+    assert cfg["assoc"] == baseline["assoc"]
+    assert load_config() == baseline
+
+
+@pytest.mark.parametrize("text", [
+    "assoc: null\n",
+    "assoc:\n  cos_mni: 0.8\n",
+    "unknown_section:\n  threshold: 1\n",
+])
+def test_malformed_or_misspelled_profiles_fail(tmp_path, text):
+    profile = tmp_path / "bad.yaml"
+    profile.write_text(text, encoding="utf-8")
+    with pytest.raises(ConfigError):
+        load_config(profiles=[profile])
+
+
+def test_typo_points_to_real_control():
+    with pytest.raises(ConfigError, match="Did you mean 'assoc.cos_min'"):
+        load_config(set_values=["assoc.cos_mni=0.8"])
+
+
+def test_required_filter_is_not_reported_as_an_invented_default():
+    cfg = load_config()
+    del cfg["filters"]["min_area_px"]
+    with pytest.raises(ConfigError, match="filters.min_area_px"):
+        validate_tuning(cfg)
+
+
+@pytest.mark.parametrize("text", [
+    "object:\n  promote_hits: 2\n  promote_hits: 9\n",
+    "[]",
+    "",
+    "value: .nan",
+    "value: 2026-01-01",
+    "value: &cycle [*cycle]",
+])
+def test_ambiguous_or_nonportable_yaml_fails(tmp_path, text):
+    path = tmp_path / "invalid.yaml"
+    path.write_text(text, encoding="utf-8")
+    with pytest.raises(ConfigError):
+        load_config(path)
+
+
+@pytest.mark.parametrize("assignment", [
+    "assoc.cos_min=1.1",
+    "assoc.cos_min=true",
+    "assoc.cos_min='0.8'",
+    "object.promote_hits=1.5",
+    "object.promote_hits=0",
+    "staging.topk_preclip=-1",
+    "staging.depth_valid_min=-0.1",
+    "filters.depth.sigma_max_m=0",
+    "object.stability_promote=null",
+    "segmentation.backend=unregistered",
+])
+def test_invalid_active_tuning_values_fail(assignment):
+    with pytest.raises(ConfigError):
+        validate_tuning(load_config(set_values=[assignment]))
+
+
+@pytest.mark.parametrize("assignment", ["broken", "assoc..cos_min=.8", "assoc.cos_min=.inf"])
+def test_invalid_assignments_fail(assignment):
+    with pytest.raises(ConfigError):
+        load_config(set_values=[assignment])
+
+
+def test_expert_settings_in_full_base_can_be_overridden(tmp_path):
+    base = load_config()
+    base["diagnostics"] = {"enabled": False, "track_drops": False}
+    path = tmp_path / "base.yaml"
+    path.write_text(yaml.safe_dump(base), encoding="utf-8")
+    cfg = load_config(path, set_values=["diagnostics.track_drops=true"])
+    assert cfg["diagnostics"]["track_drops"] is True
+    assert cfg["diagnostics"]["enabled"] is False
+
+
+def test_demo_can_select_a_backend_absent_from_demo_yaml():
+    cfg = load_config("demo_config.yaml", set_values=[
+        "segmentation.backend=fastsam", "segmentation.fastsam.conf=0.65",
+    ])
+    validate_tuning(cfg)
+    report = explain_tuning(cfg, "missing")
+    assert "segmentation.fastsam.conf = 0.65" in report
+    assert "segmentation.grounded_sam2.box_threshold =" not in report
+
+
+def test_guide_exposes_effective_controls_and_inactive_ones():
+    cfg = load_config()
+    report = explain_tuning(cfg, "pollution")
+    assert "staging.depth_valid_min = 0.02" in report
+    assert "filters.depth.valid_min_pct has no effect" in report
+    assert "gates section is not consumed" in report
+    assert "segmentation.fastsam.conf =" not in report
+    assert "not a probability of correctness" in report
+    assert "teddy bear" in report
+
+
+def test_upsert_mismatch_is_advisory_not_unsupported_constraint():
+    cfg = load_config(set_values=["ltm.ltm_min_view_bins=3"])
+    assert any("more view bins than confirmation" in warning for warning in validate_tuning(cfg))
+    demo = load_config("demo_config.yaml", set_values=["object.require_view_bins=4"])
+    assert "ltm.ltm_min_view_bins = 4 [component default]" in explain_tuning(demo, "search")
+
+
+def test_config_arguments_use_runner_default_and_override_it():
+    parser = argparse.ArgumentParser()
+    add_config_arguments(parser)
+    args = parser.parse_args(["--set", "object.promote_hits=4"])
+    cfg = config_from_args(args, "demo_config.yaml")
+    assert cfg["object"]["promote_hits"] == 4
+    assert cfg["object"]["stability_promote"] == .4
+
+
+def test_snapshot_is_valid_yaml_and_reusable_without_gpu(tmp_path, capsys):
+    main(["show", "--demo", "--set", "assoc.gate_dist_base_m=0.4"])
+    captured = capsys.readouterr()
+    cfg = yaml.safe_load(captured.out)
+    expected = load_config("demo_config.yaml", set_values=["assoc.gate_dist_base_m=0.4"])
+    assert cfg == expected
+    assert "Advisory:" not in captured.out
+    snapshot = tmp_path / "frozen.yaml"
+    snapshot.write_text(captured.out, encoding="utf-8")
+    assert load_config(snapshot) == expected
+    assert config_fingerprint(cfg) == config_fingerprint(expected)
+    assert config_fingerprint(cfg) != config_fingerprint(load_config("demo_config.yaml"))
+    assert config_fingerprint(cfg) == config_fingerprint(json.loads(json.dumps(cfg, sort_keys=True)))
+
+
+def test_cli_errors_exit_without_traceback(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["validate", "--set", "assoc.cos_min=2"])
+    assert exc.value.code == 2
+    assert "assoc.cos_min" in capsys.readouterr().err
+
+
+def test_config_dispatch_does_not_import_runtime_or_models():
+    # Make accidental model/runtime imports fail even on GPU-equipped machines.
+    code = """
+import importlib.abc
+import runpy
+import sys
+class BlockRuntime(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname in ('torch', 'numpy', 'rtsm.run', 'open_clip', 'sam2'):
+            raise RuntimeError('Unexpected heavy import: ' + fullname)
+sys.meta_path.insert(0, BlockRuntime())
+sys.argv = ['rtsm', 'config', 'validate']
+runpy.run_module('rtsm', run_name='__main__')
+"""
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "Tuning controls valid" in result.stdout


### PR DESCRIPTION
## Summary

Threshold tuning currently requires editing large packaged YAML files, and several similarly named settings do not affect the active pipeline. This change lets users keep small experiment profiles and inspect the controls relevant to missing objects, duplicate identities, bad positions, latency, or semantic search.

- Add `--config`, repeatable `--profile`, and `--set` options to the main and demo runners, preserving the packaged threshold values.
- Add GPU-independent `rtsm config explain/show/validate` commands with active-backend guidance, ineffective-setting advisories, typo detection, and validation of documented tuning controls.
- Export reusable resolved YAML snapshots and log deterministic configuration fingerprints. Document precedence, limitations, and the subsequent persistence and ONNX milestones.

Changes apply at startup. Live configuration updates, cross-session recovery, and ONNX inference remain follow-up work.

## Test Plan

- Passed 36 focused tests in `tests/test_config_tuning.py`, covering profile precedence, unchanged packaged values, invalid inputs, snapshot round trips, and CLI dispatch with runtime/model imports blocked.
- Compiled the modified Python modules and passed `git diff --check`.
- Full GPU/model execution and replay were not run. The existing `TestConfigLoader` group in `tests/test_demo_components.py` could not be collected in the separate test environment because its module imports OpenCV. Validation covers documented tuning controls, not the entire configuration or hardware compatibility.

## Checklist

- [x] Changes tested locally (focused configuration tests as described above)
- [x] No secrets or credentials committed
- [x] Updated relevant documentation
