### PR TITLE
chore(config): remove dead filter keys from packaged configs

### DIFF
--- a/docs/concepts/perception-pipeline.md
+++ b/docs/concepts/perception-pipeline.md
@@ -54,13 +54,12 @@ Heuristic filters remove unsuitable masks using depth and geometric information:
 
 | Filter | Purpose | Config key |
 |--------|---------|------------|
-| Min area | Remove noise/tiny fragments | `filters.min_area_px` (500) |
-| Max coverage | Remove walls/floors/background | `masks.max_coverage` (0.8) |
-| Aspect ratio | Remove extreme shapes | `filters.aspect_ratio` ([0.2, 5.0]) |
-| Border contact | Reject masks touching frame edges | `filters.border_touch_max_pct` (0.15) |
-| Depth validity | Require minimum valid depth pixels | `filters.depth.valid_min_pct` (0.10) |
-| Depth range | Reject too close/far objects | `filters.depth.z_min_m` / `z_max_m` |
-| Depth spread | Reject noisy depth regions | `filters.depth.sigma_max_m` (0.50) |
+| Min area | Remove noise/tiny fragments (hard reject) | `filters.min_area_px` (500) |
+| Depth range | Depth outside the range counts as invalid | `filters.depth.z_min_m` / `z_max_m` |
+| Depth validity | Reject masks with too little valid depth after edge erosion (hard reject) | `staging.depth_valid_min` (0.02), `staging.depth_erode_px` (1) |
+| Depth spread | Reject noisy depth regions (hard reject) | `filters.depth.sigma_max_m` (0.50) |
+| 3D centroid | Minimum valid depth before a 3D centroid is computed | `staging.centroid_min_valid` (0.05) |
+| Coverage / border | Rank down wall-sized or edge-touching masks (soft, see Top-K) | `staging.w_coverage`, `coverage_soft_cap`, `w_coverage_oversize`, `w_border_fraction` |
 | Planarity | Detect and score planar surfaces | `planarity.*` |
 
 !!! note "Heuristics cost varies by backend"

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -21,12 +21,13 @@ The guide shows the active backend's controls and their tradeoffs, and flags
 settings that currently have no effect. Choose from `missing`, `duplicates`,
 `pollution`, `latency`, and `search`, or omit `--symptom` for the full guide.
 
-For example, the actual mask-area cutoff is `filters.min_area_px`, not
-`staging.min_area_px`. The depth rejection fraction is
-`staging.depth_valid_min`, not `gates.min_depth_valid` or
-`filters.depth.valid_min_pct`. The `gates` and `masks` sections are not consumed
-by the current pipeline. The `segmentation.sam2` automatic-mask thresholds
-do not tune Grounded SAM2.
+Older configuration files may still carry keys the pipeline never read:
+`gates`, `masks`, `staging.min_area_px`, `filters.depth.valid_min_pct`,
+`filters.aspect_ratio`, `filters.solidity_min`, `filters.border_touch_max_pct`,
+and the `filters.border` subsection. They are reported as advisories. The live
+mask-area cutoff is `filters.min_area_px` and the live depth rejection
+fraction is `staging.depth_valid_min`. Coverage and border contact are scored
+softly through the `staging.w_*` weights rather than rejected outright.
 
 The shipped main configuration includes the RC-car experiment's five-object
 vocabulary. Inspect it before evaluating on a different scene. The demo has a
@@ -237,29 +238,25 @@ units:
 
 ## Mask Filtering & Heuristics
 
-Controls which masks pass through the perception pipeline:
+Hard rejects applied to every mask before scoring:
 
 ```yaml
-gates:
-  min_brightness: 5
-  min_std: 5
-  min_depth_valid: 0.35          # min fraction of valid depth pixels
-
-masks:
-  min_coverage: 0.005
-  max_coverage: 0.8              # reject wall/floor-sized masks
-  max_border_fraction: 0.15
-
 filters:
-  min_area_px: 500               # minimum mask area in pixels
-  aspect_ratio: [0.2, 5.0]
-  border_touch_max_pct: 0.15     # reject masks with >15% border contact
+  min_area_px: 500               # hard reject: minimum mask area in pixels
   depth:
-    z_min_m: 0.2                 # minimum depth (meters)
-    z_max_m: 8.0                 # maximum depth (meters)
-    valid_min_pct: 0.10          # min valid depth pixel fraction
-    sigma_max_m: 0.50            # max depth spread
+    z_min_m: 0.2                 # depth outside this range counts as invalid
+    z_max_m: 8.0
+    sigma_max_m: 0.50            # hard reject: max depth spread (metres)
+
+staging:
+  depth_erode_px: 1              # erode mask edges before depth statistics
+  depth_valid_min: 0.02          # hard reject: min valid-depth fraction after erosion
+  centroid_min_valid: 0.05       # min valid-depth fraction before a 3D centroid is computed
 ```
+
+Coverage, border contact, and bounding-box size are not hard gates. They enter
+the priority score through the `staging.w_*` weights in the next section, so a
+wall-sized or edge-touching mask is ranked down rather than dropped.
 
 ---
 

--- a/rtsm/cfg/demo_config.yaml
+++ b/rtsm/cfg/demo_config.yaml
@@ -117,30 +117,14 @@ time_sync:
   buffer_ttl_sec: 3
 
 # -------------------- Perception Pipeline --------------------
-gates:
-  min_brightness: 5
-  min_std: 5
-  min_depth_valid: 0.40              # DEMO: slightly stricter
-
-masks:
-  min_coverage: 0.005
-  max_coverage: 0.8
-  max_border_fraction: 0.15
-
 filters:
+  # Hard mask rejects. Coverage and border contact are scored softly through
+  # staging.w_* below rather than rejected here; shape gates are not implemented.
   min_area_px: 400                   # DEMO: lower to catch smaller objects (dolls, toys)
-  aspect_ratio: [0.2, 5.0]
-  solidity_min: 0.3
-  border_touch_max_pct: 0.15
   depth:
     z_min_m: 0.2
     z_max_m: 8.0
-    valid_min_pct: 0.10
     sigma_max_m: 0.35                # DEMO: tighter depth spread
-  border:
-    partial_min_pct: 0.30
-    extreme_drop_pct: 0.90
-    tiny_px: 150
 
 structure:
   enable: true
@@ -157,7 +141,6 @@ planarity:
 
 # -------------------- Staging --------------------
 staging:
-  min_area_px: 120
   centroid_min_valid: 0.05
   depth_valid_min: 0.02
   depth_erode_px: 1

--- a/rtsm/cfg/rtsm.yaml
+++ b/rtsm/cfg/rtsm.yaml
@@ -103,30 +103,14 @@ time_sync:
   buffer_ttl_sec: 3
 
 # -------------------- Perception Pipeline --------------------
-gates:
-  min_brightness: 5
-  min_std: 5
-  min_depth_valid: 0.35           # loosened from 0.5 - more lenient for cluttered indoor scenes
-
-masks:
-  min_coverage: 0.005
-  max_coverage: 0.8               # loosened from 0.6 - allow bigger segmentation masks
-  max_border_fraction: 0.15
-
 filters:
+  # Hard mask rejects. Coverage and border contact are scored softly through
+  # staging.w_* below rather than rejected here; shape gates are not implemented.
   min_area_px: 500                # lowered from 700 - catch smaller indoor objects
-  aspect_ratio: [0.2, 5.0]
-  solidity_min: 0.3
-  border_touch_max_pct: 0.15      # tightened: reject masks with >15% border contact
   depth:
     z_min_m: 0.2
     z_max_m: 8.0
-    valid_min_pct: 0.10
     sigma_max_m: 0.50             # loosened from 0.25 - allow reflective/multi-plane objects (TVs, glass)
-  border:
-    partial_min_pct: 0.30
-    extreme_drop_pct: 0.90
-    tiny_px: 150
 
 structure:
   enable: true
@@ -143,8 +127,6 @@ planarity:
 
 # -------------------- Staging & Prioritization --------------------
 staging:
-  # Basic thresholds
-  min_area_px: 120
   centroid_min_valid: 0.05       # loosened from 0.15 - allow centroid even with very sparse depth
   depth_valid_min: 0.02          # loosened from 0.10 - allow near-zero depth on reflective surfaces (TVs, mirrors)
   depth_erode_px: 1              # reduced: 1px erosion to preserve more mask area for centroid

--- a/rtsm/cfg/tuning.py
+++ b/rtsm/cfg/tuning.py
@@ -146,6 +146,10 @@ def validate_tuning(cfg: dict) -> list[str]:
         ("masks", "The masks section is not consumed by the current pipeline."),
         ("staging.min_area_px", "staging.min_area_px has no effect; use filters.min_area_px."),
         ("filters.depth.valid_min_pct", "filters.depth.valid_min_pct has no effect; use staging.depth_valid_min."),
+        ("filters.aspect_ratio", "filters.aspect_ratio has no effect; shape gates are not implemented."),
+        ("filters.solidity_min", "filters.solidity_min has no effect; shape gates are not implemented."),
+        ("filters.border_touch_max_pct", "filters.border_touch_max_pct has no effect; border contact is scored via staging.w_border_fraction."),
+        ("filters.border", "The filters.border section has no effect; border contact is scored via staging.w_border_fraction."),
     )
     for path, message in ineffective:
         if _get(cfg, path) is not None:
@@ -157,11 +161,6 @@ def validate_tuning(cfg: dict) -> list[str]:
         warnings.append("LTM requires more view bins than confirmation; some confirmed objects may be absent from semantic search.")
     if not _get(cfg, "vectors.enable", True):
         warnings.append("Vector storage is disabled; semantic search will be unavailable.")
-    if backend == "grounded_sam2":
-        for key in ("pred_iou_thresh", "stability_score_thresh", "points_per_side"):
-            if _get(cfg, f"segmentation.sam2.{key}") is not None:
-                warnings.append("SAM2 automatic-mask thresholds/grid settings do not configure grounded_sam2; only sam2.model_id supplies its fallback model.")
-                break
     return warnings
 
 

--- a/tests/test_config_tuning.py
+++ b/tests/test_config_tuning.py
@@ -130,13 +130,36 @@ def test_guide_exposes_effective_controls_and_inactive_ones():
     cfg = load_config()
     report = explain_tuning(cfg, "pollution")
     assert "staging.depth_valid_min = 0.02" in report
-    assert "filters.depth.valid_min_pct has no effect" in report
-    assert "gates section is not consumed" in report
+    # Packaged defaults carry no legacy keys, so no ineffective-setting advisories.
+    assert "has no effect" not in report and "not consumed" not in report
     assert "segmentation.fastsam.conf =" not in report
     assert "not a probability of correctness" in report
     assert "Detection vocabulary:" in report
     custom = load_config(set_values=["segmentation.grounded_sam2.vocab=[teddy bear]"])
     assert "Detection vocabulary: ['teddy bear']" in explain_tuning(custom, "pollution")
+
+
+def test_legacy_keys_in_user_config_are_advisories_not_overrides(tmp_path):
+    legacy = load_config()
+    legacy["gates"] = {"min_brightness": 5, "min_std": 5, "min_depth_valid": .35}
+    legacy["masks"] = {"min_coverage": .005, "max_coverage": .8, "max_border_fraction": .15}
+    legacy["staging"]["min_area_px"] = 120
+    legacy["filters"].update(aspect_ratio=[.2, 5.], solidity_min=.3, border_touch_max_pct=.15)
+    legacy["filters"]["depth"]["valid_min_pct"] = .1
+    legacy["filters"]["border"] = {"partial_min_pct": .3, "extreme_drop_pct": .9, "tiny_px": 150}
+    path = tmp_path / "legacy.yaml"
+    path.write_text(yaml.safe_dump(legacy), encoding="utf-8")
+    cfg = load_config(path)
+    warnings = validate_tuning(cfg)
+    for needle in ("gates section", "masks section", "staging.min_area_px",
+                   "filters.depth.valid_min_pct", "filters.aspect_ratio",
+                   "filters.solidity_min", "filters.border_touch_max_pct",
+                   "filters.border section"):
+        assert any(needle in warning for warning in warnings), needle
+    assert "gates section is not consumed" in explain_tuning(cfg, "pollution")
+    # The legacy keys no longer exist in any packaged base, so they are not valid overrides.
+    with pytest.raises(ConfigError, match="Unknown or malformed override"):
+        load_config(set_values=["gates.min_brightness=5"])
 
 
 def test_upsert_mismatch_is_advisory_not_unsupported_constraint():


### PR DESCRIPTION
## Summary

Follow-up to #25. Every plain `rtsm run` or `rtsm demo` on untouched defaults logged six configuration advisories, because both packaged YAMLs still shipped keys the pipeline never reads.

An audit of every leaf under `gates`, `masks`, `filters`, and `staging` found 14 keys with zero consumers anywhere in `rtsm/`:

| Key | Status |
|---|---|
| `staging.min_area_px` | duplicate of live `filters.min_area_px` |
| `filters.depth.valid_min_pct`, `gates.min_depth_valid` | duplicates of live `staging.depth_valid_min` |
| `masks.min_coverage`, `masks.max_coverage`, `masks.max_border_fraction`, `filters.border_touch_max_pct`, `filters.border.*` (3) | hard gates superseded by soft scoring via `staging.w_*` (MaskStats labels these "SOFT FEATURES") |
| `gates.min_brightness`, `gates.min_std` | frame-quality gate that was never implemented |
| `filters.aspect_ratio`, `filters.solidity_min` | shape gates that were never implemented |

No commit in the repo history ever read them. Removing them cannot change pipeline behaviour.

## Changes

- Remove the 14 leaves from `rtsm/cfg/rtsm.yaml` and `rtsm/cfg/demo_config.yaml`. Every surviving key keeps its value (asserted by the edit script).
- Extend the ineffective-setting advisories in `tuning.py` with the shape, border, and `filters.border` keys, so users carrying legacy config files are still warned.
- Drop the SAM2 advisory. It fired because the shipped `segmentation.sam2` section exists while the backend is `grounded_sam2`, but that section is legitimately there for `backend: sam2`.
- Correct `docs/concepts/perception-pipeline.md`, whose filter table listed four dead keys as live filters, and `docs/getting-started/configuration.md`, whose example block contradicted the paragraph #25 added above it.
- Repoint the advisory test at a temporary legacy config, and assert the legacy keys are no longer accepted as `--profile` / `--set` overrides (the override validator only accepts keys present in a packaged or base config).

## Result

Untouched defaults now emit one advisory: `centroid_min_valid` (0.05) exceeds `depth_valid_min` (0.02), so masks with 2-5% valid depth pass the depth gate but get no 3D centroid. Both values carry comments saying they were loosened for reflective surfaces. That is a genuine tuning question, not noise, so it stays.

## Test plan

- [x] `pytest tests/test_config_tuning.py tests/test_demo_components.py -k "not Segment"`: 56 passed
- [x] `rtsm config validate` and `rtsm config validate --demo`: one advisory each
- [x] `rtsm config validate --set gates.min_brightness=5` is rejected as an unknown override
- [x] `git grep` for every removed key outside `rtsm/cfg` and `rtsm/static`: no matches
- [x] `git diff --check` clean
- [ ] Not run: GPU pipeline. Not needed, since no removed key had a reader.

## Follow-ups (out of scope here)

1. **Frame-quality gate.** `gates.min_brightness` / `gates.min_std` described a real missing feature: dark, blank, or lens-covered frames go straight into segmentation. Implement it properly (grayscale mean/std plus a frame-level valid-depth fraction, skip before segmentation) with a test and replay check, then reintroduce the keys.
2. **Other sections.** The same zero-consumer audit over the whole of `rtsm.yaml` flags 17 more leaves outside the filter area: all of `time_sync`, `io_sweep`, `camera.aligned_to`, `planarity.inlier_pct_min`, `slam.accept_pose_corrections`, `slam.log_pose_source`, `structure.{angle_floor_deg,max_rms_m,min_support_px,wall_dot_max}`, and `sweep_cache.{enable_plane_dedup,hysteresis_frac,plane_normal_bins,plane_quant_step}`. Some may be read by out-of-tree consumers (ROS bridge, examples), so they need a per-key check before removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
