### PR TITLE
feat(core): frame-quality gate skips unusable frames before segmentation

### DIFF
--- a/docs/concepts/perception-pipeline.md
+++ b/docs/concepts/perception-pipeline.md
@@ -46,6 +46,14 @@ Dual-confirmed masks receive a priority boost and are 1.5x more likely to be sel
 | `fastsam` | FastSAM only (class-agnostic, fast) | ~50 ms |
 | `yoloe` | YOLOE only (open-vocab, prompt-free) | ~60 ms |
 
+### Frame-quality gate
+
+Before any segmentation pass, the frame-quality gate (`gates.*`) measures grey
+level, contrast, and the valid-depth fraction on a strided subsample of the
+frame and skips black, blank, or depth-less frames. Skips are counted as
+`frame_rejections` in the latency analytics. See
+[Configuration](../getting-started/configuration.md#frame-quality-gate).
+
 ---
 
 ## 2. Mask Heuristics

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -22,7 +22,7 @@ settings that currently have no effect. Choose from `missing`, `duplicates`,
 `pollution`, `latency`, and `search`, or omit `--symptom` for the full guide.
 
 Older configuration files may still carry keys the pipeline never read:
-`gates`, `masks`, `staging.min_area_px`, `filters.depth.valid_min_pct`,
+`masks`, `staging.min_area_px`, `filters.depth.valid_min_pct`,
 `filters.aspect_ratio`, `filters.solidity_min`, `filters.border_touch_max_pct`,
 and the `filters.border` subsection. They are reported as advisories. The live
 mask-area cutoff is `filters.min_area_px` and the live depth rejection
@@ -233,6 +233,28 @@ units:
   depth_m_per_unit: 0.001     # mm → meters
   pose_m_per_unit: 1.0        # RTABMap poses are already in meters
 ```
+
+---
+
+## Frame-Quality Gate
+
+Runs before segmentation on a strided subsample of each frame, so it costs well
+under a millisecond and saves a full segmentation pass on unusable frames:
+
+```yaml
+gates:
+  enable: true
+  min_brightness: 5.0            # mean grey level (0-255); below = dark or covered lens
+  min_std: 5.0                   # grey standard deviation; below = blank, uniform frame
+  min_depth_valid: 0.02          # fraction of finite, positive depth pixels; below = depth failure
+  sample_stride: 4               # pixel subsampling for the statistics
+```
+
+The defaults are deliberately conservative: they catch black, blank, and
+depth-less frames only. Skipped frames are counted as `frame_rejections` in the
+latency analytics and summarised in the log at most every ten seconds. Raise the
+thresholds only with replay evidence, since a frame-level gate that is too
+strict silently starves the map.
 
 ---
 

--- a/rtsm/analytics/latency_analytics.py
+++ b/rtsm/analytics/latency_analytics.py
@@ -48,6 +48,7 @@ class LatencySecondBucket:
     # Drop counters (per second)
     queue_drops: int = 0
     gate_rejections: int = 0
+    frame_rejections: int = 0   # frame-quality gate (gates.*)
     throttle_skips: int = 0
     tracking_drops: int = 0
     # Queue pressure
@@ -111,6 +112,7 @@ class PipelineLatencyBuffer:
 
         # Drop counters (all monotonically increasing, diffed at rollup)
         self._gate_rejections: int = 0
+        self._frame_rejections: int = 0
         self._queue_drops: int = 0
         self._throttle_skips: int = 0
         self._tracking_drops: int = 0
@@ -122,6 +124,7 @@ class PipelineLatencyBuffer:
         self._last_rollup_ts: float = time.monotonic()
         self._last_rollup_received: int = 0
         self._last_rollup_rejections: int = 0
+        self._last_rollup_frame_rejections: int = 0
         self._last_rollup_queue_drops: int = 0
         self._last_rollup_throttle_skips: int = 0
         self._last_rollup_tracking_drops: int = 0
@@ -152,6 +155,11 @@ class PipelineLatencyBuffer:
         """Called when the ingest gate rejects a frame."""
         with self._lock:
             self._gate_rejections += 1
+
+    def record_frame_rejection(self) -> None:
+        """Called when the frame-quality gate skips a frame."""
+        with self._lock:
+            self._frame_rejections += 1
 
     def record_queue_drop(self) -> None:
         """Called when IngestQueue.put() returns False (queue full)."""
@@ -195,6 +203,7 @@ class PipelineLatencyBuffer:
                 self._last_rollup_ts = now_mono
                 self._last_rollup_received = self._received_count
                 self._last_rollup_rejections = self._gate_rejections
+                self._last_rollup_frame_rejections = self._frame_rejections
                 self._last_rollup_queue_drops = self._queue_drops
                 self._last_rollup_throttle_skips = self._throttle_skips
                 self._last_rollup_tracking_drops = self._tracking_drops
@@ -216,6 +225,7 @@ class PipelineLatencyBuffer:
 
             # Drop deltas since last rollup
             gate_rej = self._gate_rejections - self._last_rollup_rejections
+            frame_rej = self._frame_rejections - self._last_rollup_frame_rejections
             q_drops = self._queue_drops - self._last_rollup_queue_drops
             throttle = self._throttle_skips - self._last_rollup_throttle_skips
             tracking = self._tracking_drops - self._last_rollup_tracking_drops
@@ -234,6 +244,7 @@ class PipelineLatencyBuffer:
                 effective_ratio=round(processing_hz / max(0.001, input_hz), 3),
                 queue_drops=q_drops,
                 gate_rejections=gate_rej,
+                frame_rejections=frame_rej,
                 throttle_skips=throttle,
                 tracking_drops=tracking,
                 queue_depth_mean=q_mean,
@@ -259,6 +270,7 @@ class PipelineLatencyBuffer:
             self._last_rollup_ts = now_mono
             self._last_rollup_received = self._received_count
             self._last_rollup_rejections = self._gate_rejections
+            self._last_rollup_frame_rejections = self._frame_rejections
             self._last_rollup_queue_drops = self._queue_drops
             self._last_rollup_throttle_skips = self._throttle_skips
             self._last_rollup_tracking_drops = self._tracking_drops
@@ -359,6 +371,7 @@ class PipelineLatencyBuffer:
             self._second_buckets.clear()
             self._received_count = 0
             self._gate_rejections = 0
+            self._frame_rejections = 0
             self._queue_drops = 0
             self._throttle_skips = 0
             self._tracking_drops = 0
@@ -366,6 +379,7 @@ class PipelineLatencyBuffer:
             self._last_rollup_ts = time.monotonic()
             self._last_rollup_received = 0
             self._last_rollup_rejections = 0
+            self._last_rollup_frame_rejections = 0
             self._last_rollup_queue_drops = 0
             self._last_rollup_throttle_skips = 0
             self._last_rollup_tracking_drops = 0

--- a/rtsm/cfg/demo_config.yaml
+++ b/rtsm/cfg/demo_config.yaml
@@ -117,6 +117,16 @@ time_sync:
   buffer_ttl_sec: 3
 
 # -------------------- Perception Pipeline --------------------
+gates:
+  # Frame-quality gate: skip frames that cannot yield usable masks before
+  # paying for a segmentation pass. Conservative defaults catch black, blank,
+  # and depth-less frames only. Raise them with replay evidence, not intuition.
+  enable: true
+  min_brightness: 5.0             # mean grey level (0-255); below = dark or covered lens
+  min_std: 5.0                    # grey standard deviation; below = blank, uniform frame
+  min_depth_valid: 0.02           # fraction of finite, positive depth pixels; below = depth failure
+  sample_stride: 4                # pixel subsampling for the statistics (<1 ms)
+
 filters:
   # Hard mask rejects. Coverage and border contact are scored softly through
   # staging.w_* below rather than rejected here; shape gates are not implemented.

--- a/rtsm/cfg/rtsm.yaml
+++ b/rtsm/cfg/rtsm.yaml
@@ -103,6 +103,16 @@ time_sync:
   buffer_ttl_sec: 3
 
 # -------------------- Perception Pipeline --------------------
+gates:
+  # Frame-quality gate: skip frames that cannot yield usable masks before
+  # paying for a segmentation pass. Conservative defaults catch black, blank,
+  # and depth-less frames only. Raise them with replay evidence, not intuition.
+  enable: true
+  min_brightness: 5.0             # mean grey level (0-255); below = dark or covered lens
+  min_std: 5.0                    # grey standard deviation; below = blank, uniform frame
+  min_depth_valid: 0.02           # fraction of finite, positive depth pixels; below = depth failure
+  sample_stride: 4                # pixel subsampling for the statistics (<1 ms)
+
 filters:
   # Hard mask rejects. Coverage and border contact are scored softly through
   # staging.w_* below rather than rejected here; shape gates are not implemented.

--- a/rtsm/cfg/tuning.py
+++ b/rtsm/cfg/tuning.py
@@ -21,7 +21,8 @@ class Control:
 
 
 # Defaults trace to segmentation/__init__.py, utils/mask_staging.py,
-# core/pipeline.py, core/association.py, stores/working_memory.py and run.py.
+# core/pipeline.py, core/frame_gate.py, core/association.py,
+# stores/working_memory.py and run.py.
 # None denotes a required setting whose consumer has no fallback.
 CONTROLS = (
     Control("segmentation.grounded_sam2.box_threshold", .25, ("missing", "pollution"),
@@ -39,6 +40,15 @@ CONTROLS = (
     Control("segmentation.sam2.pred_iou_thresh", .7, ("missing", "pollution"),
             "Auto-mask quality cutoff; this is not used by the grounded_sam2 factory.",
             maximum=1, backends=("sam2",)),
+    Control("gates.min_brightness", 5., ("missing", "latency"),
+            "Frame-quality gate: mean grey level below this skips the frame before segmentation.",
+            maximum=255),
+    Control("gates.min_std", 5., ("missing", "latency"),
+            "Frame-quality gate: grey standard deviation below this marks a blank frame. Plain walls at close range can trip it.",
+            maximum=255),
+    Control("gates.min_depth_valid", .02, ("missing", "pollution"),
+            "Frame-quality gate: fraction of finite, positive depth pixels below this skips the frame. Large halls and windows lower it.",
+            maximum=1),
     Control("filters.min_area_px", None, ("missing",),
             "Actual mask area cutoff in pixels. Lower for small objects; fragments may increase.",
             minimum=1, integer=True),
@@ -113,6 +123,8 @@ def active_controls(cfg: dict):
             continue
         if control.path == "assoc.cos_min" and not _get(cfg, "assoc.use_embeddings", True):
             continue
+        if control.path.startswith("gates.") and not _get(cfg, "gates.enable", True):
+            continue
         if control.path.startswith("io.websocket.") and _get(cfg, "io.receiver", "zeromq") != "websocket":
             continue
         yield control
@@ -142,7 +154,6 @@ def validate_tuning(cfg: dict) -> list[str]:
 
     warnings = []
     ineffective = (
-        ("gates", "The gates section is not consumed by the current pipeline."),
         ("masks", "The masks section is not consumed by the current pipeline."),
         ("staging.min_area_px", "staging.min_area_px has no effect; use filters.min_area_px."),
         ("filters.depth.valid_min_pct", "filters.depth.valid_min_pct has no effect; use staging.depth_valid_min."),

--- a/rtsm/core/frame_gate.py
+++ b/rtsm/core/frame_gate.py
@@ -1,0 +1,102 @@
+"""Frame-quality gate: skip frames that cannot yield usable masks.
+
+Runs before segmentation on a strided subsample of the frame, so it costs well
+under a millisecond and saves a full segmentation pass on black, blank, or
+depth-less frames. The defaults are deliberately conservative; a frame-level
+gate that is too strict silently starves the map, so raise thresholds only with
+replay evidence.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+logger = logging.getLogger("rtsm.frame_gate")
+
+REASON_DARK = "dark"
+REASON_FLAT = "flat"
+REASON_DEPTH = "depth"
+REASONS = (REASON_DARK, REASON_FLAT, REASON_DEPTH)
+
+
+@dataclass(frozen=True)
+class FrameGateDecision:
+    accept: bool
+    reason: str            # "" when accepted, otherwise one of REASONS
+    brightness: float      # mean grey level, 0-255
+    contrast: float        # grey standard deviation
+    depth_valid: float     # fraction of finite, positive depth pixels; 1.0 when no depth given
+
+
+class FrameQualityGate:
+    """Cheap per-frame usability check driven by the ``gates`` config section."""
+
+    def __init__(self, cfg: Dict[str, Any], log_interval_s: float = 10.0):
+        g = cfg.get("gates") or {}
+        self.enabled = bool(g.get("enable", True))
+        self.min_brightness = float(g.get("min_brightness", 5.0))
+        self.min_std = float(g.get("min_std", 5.0))
+        self.min_depth_valid = float(g.get("min_depth_valid", 0.02))
+        self.stride = max(1, int(g.get("sample_stride", 4)))
+        self.checked = 0
+        self.rejections: Dict[str, int] = {reason: 0 for reason in REASONS}
+        self._log_interval_s = float(log_interval_s)
+        self._last_log_mono = float("-inf")
+        self._unlogged = 0
+
+    def check(self, rgb: Any, depth_m: Optional[np.ndarray]) -> FrameGateDecision:
+        """Measure the frame and decide. Statistics are computed even when disabled."""
+        img = np.asarray(rgb)
+        sub = img[:: self.stride, :: self.stride]
+        if sub.ndim == 3 and sub.shape[-1] >= 3:
+            s = sub[..., :3].astype(np.float32)
+            grey = s[..., 0] * 0.299 + s[..., 1] * 0.587 + s[..., 2] * 0.114
+        else:
+            grey = sub.astype(np.float32)
+        brightness = float(grey.mean()) if grey.size else 0.0
+        contrast = float(grey.std()) if grey.size else 0.0
+
+        depth_valid = 1.0
+        if depth_m is not None:
+            d = np.asarray(depth_m)[:: self.stride, :: self.stride]
+            if d.size:
+                with np.errstate(invalid="ignore"):
+                    depth_valid = float(np.mean(np.isfinite(d) & (d > 0)))
+            else:
+                depth_valid = 0.0
+
+        reason = ""
+        if self.enabled:
+            if brightness < self.min_brightness:
+                reason = REASON_DARK
+            elif contrast < self.min_std:
+                reason = REASON_FLAT
+            elif depth_valid < self.min_depth_valid:
+                reason = REASON_DEPTH
+
+        self.checked += 1
+        if reason:
+            self.rejections[reason] += 1
+            self._unlogged += 1
+        return FrameGateDecision(not reason, reason, brightness, contrast, depth_valid)
+
+    def maybe_log(self, decision: FrameGateDecision, now_mono: Optional[float] = None) -> bool:
+        """Log the first rejection immediately, then at most one summary per interval."""
+        now = time.monotonic() if now_mono is None else now_mono
+        if now - self._last_log_mono < self._log_interval_s:
+            return False
+        logger.warning(
+            "frame-quality gate skipped %d frame(s) since last report (%s); latest reason=%s "
+            "brightness=%.1f std=%.1f depth_valid=%.2f",
+            self._unlogged,
+            ", ".join(f"{k}={v}" for k, v in self.rejections.items()),
+            decision.reason, decision.brightness, decision.contrast, decision.depth_valid,
+        )
+        self._last_log_mono = now
+        self._unlogged = 0
+        return True

--- a/rtsm/core/pipeline.py
+++ b/rtsm/core/pipeline.py
@@ -8,6 +8,7 @@ import torch
 import cv2
 from PIL import Image
 
+from rtsm.core.frame_gate import FrameQualityGate
 from rtsm.utils.mask_staging import run_heuristics, MaskStats
 from rtsm.utils.prepare_ann import prepare_ann
 from rtsm.utils.periodic_logger import PeriodicLogger
@@ -73,6 +74,8 @@ class Pipeline:
         self.sweep_cache = sweep_cache or SweepCache()
         self._seg_analytics = seg_analytics
         self._latency_analytics = latency_analytics
+        # Frame-quality gate (gates.*): skips unusable frames before segmentation
+        self.frame_gate = FrameQualityGate(cfg)
         # Frame-flow heartbeat read by the watchdog (see rtsm/core/watchdog.py)
         self.heartbeat = PipelineHeartbeat()
 
@@ -179,6 +182,23 @@ class Pipeline:
                     self._latency_analytics.record_gate_rejection()
                 except Exception:
                     pass
+            return
+
+        # Frame-quality gate: skip black, blank, or depth-less frames before paying
+        # for a segmentation pass. Keyframe bookkeeping above has already run, and
+        # record_processed() below is skipped, so the sweep cache is not marked.
+        try:
+            fq = self.frame_gate.check(snap.rgb, snap.depth_m)
+        except Exception as e:
+            logger.warning(f"frame-quality gate error; proceeding: {e}")
+            fq = None
+        if fq is not None and not fq.accept:
+            if self._latency_analytics:
+                try:
+                    self._latency_analytics.record_frame_rejection()
+                except Exception:
+                    pass
+            self.frame_gate.maybe_log(fq)
             return
 
         t_step_start = time.perf_counter()

--- a/tests/test_config_tuning.py
+++ b/tests/test_config_tuning.py
@@ -141,7 +141,6 @@ def test_guide_exposes_effective_controls_and_inactive_ones():
 
 def test_legacy_keys_in_user_config_are_advisories_not_overrides(tmp_path):
     legacy = load_config()
-    legacy["gates"] = {"min_brightness": 5, "min_std": 5, "min_depth_valid": .35}
     legacy["masks"] = {"min_coverage": .005, "max_coverage": .8, "max_border_fraction": .15}
     legacy["staging"]["min_area_px"] = 120
     legacy["filters"].update(aspect_ratio=[.2, 5.], solidity_min=.3, border_touch_max_pct=.15)
@@ -151,15 +150,23 @@ def test_legacy_keys_in_user_config_are_advisories_not_overrides(tmp_path):
     path.write_text(yaml.safe_dump(legacy), encoding="utf-8")
     cfg = load_config(path)
     warnings = validate_tuning(cfg)
-    for needle in ("gates section", "masks section", "staging.min_area_px",
+    for needle in ("masks section", "staging.min_area_px",
                    "filters.depth.valid_min_pct", "filters.aspect_ratio",
                    "filters.solidity_min", "filters.border_touch_max_pct",
                    "filters.border section"):
         assert any(needle in warning for warning in warnings), needle
-    assert "gates section is not consumed" in explain_tuning(cfg, "pollution")
+    assert "masks section is not consumed" in explain_tuning(cfg, "pollution")
     # The legacy keys no longer exist in any packaged base, so they are not valid overrides.
     with pytest.raises(ConfigError, match="Unknown or malformed override"):
-        load_config(set_values=["gates.min_brightness=5"])
+        load_config(set_values=["masks.max_coverage=0.8"])
+
+
+def test_frame_gate_controls_follow_gates_enable():
+    assert "gates.min_brightness = 5.0" in explain_tuning(load_config(), "latency")
+    off = load_config(set_values=["gates.enable=false"])
+    assert "gates.min_brightness" not in explain_tuning(off, "latency")
+    with pytest.raises(ConfigError, match="gates.min_brightness"):
+        validate_tuning(load_config(set_values=["gates.min_brightness=300"]))
 
 
 def test_upsert_mismatch_is_advisory_not_unsupported_constraint():

--- a/tests/test_frame_gate.py
+++ b/tests/test_frame_gate.py
@@ -1,0 +1,108 @@
+"""Frame-quality gate: pure numpy, no GPU or model downloads."""
+
+import logging
+
+import numpy as np
+import pytest
+
+from rtsm.core.frame_gate import (
+    REASON_DARK,
+    REASON_DEPTH,
+    REASON_FLAT,
+    FrameQualityGate,
+)
+
+H, W = 96, 128
+_rng = np.random.default_rng(0)
+
+
+def scene_rgb():
+    return _rng.integers(0, 256, size=(H, W, 3), dtype=np.uint8)
+
+
+def scene_depth():
+    d = _rng.uniform(0.5, 4.0, size=(H, W)).astype(np.float32)
+    d[:8] = np.nan  # a band of invalid depth is normal
+    return d
+
+
+def gate(**overrides):
+    return FrameQualityGate({"gates": overrides})
+
+
+def test_normal_frame_is_accepted():
+    d = gate().check(scene_rgb(), scene_depth())
+    assert d.accept and d.reason == ""
+    assert d.brightness > 100 and d.contrast > 30
+    assert 0.9 < d.depth_valid < 1.0
+
+
+def test_black_frame_is_dark():
+    d = gate().check(np.zeros((H, W, 3), np.uint8), scene_depth())
+    assert not d.accept and d.reason == REASON_DARK
+
+
+def test_uniform_frame_is_flat():
+    d = gate().check(np.full((H, W, 3), 120, np.uint8), scene_depth())
+    assert not d.accept and d.reason == REASON_FLAT
+    assert d.brightness == pytest.approx(120.0) and d.contrast == 0.0
+
+
+@pytest.mark.parametrize("bad", [np.full((H, W), np.nan, np.float32), np.zeros((H, W), np.float32)])
+def test_depth_failure_is_rejected(bad):
+    d = gate().check(scene_rgb(), bad)
+    assert not d.accept and d.reason == REASON_DEPTH and d.depth_valid == 0.0
+
+
+def test_missing_depth_does_not_reject():
+    d = gate().check(scene_rgb(), None)
+    assert d.accept and d.depth_valid == 1.0
+
+
+def test_disabled_gate_still_measures_but_accepts():
+    d = gate(enable=False).check(np.zeros((H, W, 3), np.uint8), None)
+    assert d.accept and d.brightness == 0.0
+
+
+def test_thresholds_come_from_config():
+    assert gate(min_brightness=200).check(np.full((H, W, 3), 150, np.uint8), None).reason == REASON_DARK
+    quarter = np.where(np.arange(W) < W // 4, 1.0, np.nan).astype(np.float32)[None].repeat(H, 0)
+    d = gate(min_depth_valid=0.5).check(scene_rgb(), quarter)
+    assert d.reason == REASON_DEPTH and d.depth_valid == pytest.approx(0.25)
+
+
+def test_stride_odd_shapes_and_array_like_input():
+    rgb, depth = scene_rgb()[:95, :127], scene_depth()[:95, :127]
+    assert gate(sample_stride=7).check(rgb, depth).accept
+    assert gate(sample_stride=1).check(list(rgb), depth).accept
+    assert gate().check(rgb[..., 0], depth).accept  # greyscale input
+
+
+def test_counters_and_rate_limited_log(caplog):
+    g = FrameQualityGate({}, log_interval_s=10.0)
+    black = np.zeros((H, W, 3), np.uint8)
+    with caplog.at_level(logging.WARNING, logger="rtsm.frame_gate"):
+        assert g.maybe_log(g.check(black, None), now_mono=0.0)
+        assert not g.maybe_log(g.check(black, None), now_mono=5.0)
+        assert g.check(scene_rgb(), None).accept
+        assert g.maybe_log(g.check(black, None), now_mono=10.0)
+    assert g.checked == 4
+    assert g.rejections == {REASON_DARK: 3, REASON_FLAT: 0, REASON_DEPTH: 0}
+    assert "skipped 2 frame(s)" in caplog.records[-1].getMessage()
+
+
+def test_latency_analytics_rolls_up_frame_rejections():
+    from rtsm.analytics.latency_analytics import PipelineLatencyBuffer
+
+    la = PipelineLatencyBuffer()
+    la.roll_up_second()  # prime the rollup cursor
+    la.record_frame_rejection()
+    la.record_frame_rejection()
+    la.record_gate_rejection()
+    bucket = la.roll_up_second()
+    assert bucket.frame_rejections == 2 and bucket.gate_rejections == 1
+    assert la.roll_up_second().frame_rejections == 0  # cursor advanced
+    la.clear()
+    la.roll_up_second()
+    la.record_frame_rejection()
+    assert la.roll_up_second().frame_rejections == 1


### PR DESCRIPTION
## Summary

Follow-up to #26. The original `gates.min_brightness` / `min_std` / `min_depth_valid` keys described a frame-level usability check that was never implemented, so dark, blank, and depth-less frames went straight into a full segmentation pass. #26 removed them as dead keys; this PR reintroduces them as a real feature.

## Design

- **`rtsm/core/frame_gate.py`**: `FrameQualityGate` measures grey level, grey standard deviation, and the fraction of finite positive depth pixels on a strided subsample of the frame (stride 4, well under a millisecond). Pure numpy, no model imports.
- **Placement**: runs in `Pipeline.run_one_step` after the ingest gate and before segmentation. Keyframe grace-window bookkeeping in the ingest gate has already happened, and `record_processed()` is skipped, so a rejected frame never marks the sweep cache as observed. Wrapped in try/except so a malformed frame can never take the pipeline down.
- **Observability**: skips are counted as `frame_rejections` in the latency analytics buckets, mirroring `gate_rejections` through rollup, cursor advance, and `/reset`. The gate logs the first skip immediately and then at most one summary every ten seconds with per-reason counts.
- **Config**: `gates` section restored in both packaged YAMLs with `enable`, `min_brightness`, `min_std`, `min_depth_valid`, `sample_stride`. Three new tuning controls (0-255 and 0-1 ranges) that are hidden from `rtsm config explain` when `gates.enable` is false. The #26 legacy-key advisory for `gates` is removed.
- **Defaults are conservative on purpose**: 5 / 5 / 0.02 catch black, blank, and depth-less frames only. A frame-level gate that is too strict silently starves the map, so raising them needs replay evidence. The old never-active values (0.35 / 0.40 depth) were not adopted for that reason.

## Test plan

- [x] `pytest tests/test_frame_gate.py tests/test_config_tuning.py tests/test_demo_components.py -k "not Segment"`: 68 passed. Covers dark, flat, all-NaN and all-zero depth, missing depth, disabled gate, config thresholds, odd shapes and array-like input, counters and rate-limited logging, and the analytics rollup.
- [x] **Replay on the RTX 5090, defaults** (`rtsm --replay recordings/session1`): 240 frames, 0 skips. Real ARKit frames measure brightness ~131-142, std ~66-77, depth_valid ~0.75-0.83, so defaults sit far below real data.
- [x] **Replay, forced rejection** (`--set gates.min_brightness=255`): all 23 accepted frames skipped, first logged immediately, remaining 22 in one summary, replay drained cleanly with no segmentation pass.
- [x] `--set gates.min_brightness=300` is refused at startup by the tuning validation.
- [x] `rtsm config validate` on both bases: one advisory (the pre-existing centroid threshold note).
- [x] `git -c core.whitespace=cr-at-eol diff --check` clean (`pipeline.py` is CRLF in the index, as before).

## Follow-ups

- The analytics dashboard frontend does not yet render `frame_rejections`; the field is in the bucket JSON and needs a frontend rebuild to display.
- Aspect-ratio and solidity shape gates remain unimplemented and out of the config, pending evidence they help on this data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
