### PR TITLE
fix(core): explain and log suppressed pipeline exceptions

### DIFF
--- a/rtsm/core/pipeline.py
+++ b/rtsm/core/pipeline.py
@@ -93,6 +93,7 @@ class Pipeline:
             while self._running:
                 self.run_one_step()
         except KeyboardInterrupt:
+            # Ctrl+C is a normal stop request; the finally block releases models.
             pass
         finally:
             self.shutdown()
@@ -178,7 +179,7 @@ class Pipeline:
                 try:
                     self._latency_analytics.record_gate_rejection()
                 except Exception:
-                    pass
+                    logger.debug("Failed to record ingest-gate rejection", exc_info=True)
             return
 
         t_step_start = time.perf_counter()
@@ -307,7 +308,7 @@ class Pipeline:
                     c = int(stats_assoc.get("created", 0))
                     logger.debug(f"assoc: matched={m} created={c}")
             except Exception:
-                pass
+                logger.debug("Failed to summarize association statistics", exc_info=True)
 
         t_assoc_end = time.perf_counter()
 
@@ -418,7 +419,7 @@ class Pipeline:
                 timestamp = float(pkt.time.t_wall_utc_s or pkt.time.t_mono_s or 0.0)
                 self.working_mem.update_robot_pose(twc, q, timestamp)
         except Exception:
-            pass
+            logger.warning("Post-processing ingest bookkeeping or robot-pose update failed", exc_info=True)
 
     # -------- internals --------
     def _get_snapshot_via_queue(self) -> Tuple[Optional[Snapshot], Optional[FramePacket]]:
@@ -847,11 +848,11 @@ class Pipeline:
         try:
             self.segmenter.close()
         except Exception:
-            pass
+            logger.warning("Failed to close segmenter during shutdown", exc_info=True)
         try:
             self.clip.close()
         except Exception:
-            pass
+            logger.warning("Failed to close CLIP adapter during shutdown", exc_info=True)
 
     # -------- single test  step (hardcoded import) --------
     @torch.no_grad()


### PR DESCRIPTION
## Summary

Address the github-code-quality bot's six Empty except findings in `rtsm/core/pipeline.py` that are present on main (reported on PR #23). Add debug diagnostics for optional analytics/statistics failures and warning diagnostics for ingest bookkeeping/robot-pose updates and model cleanup failures, all with exception tracebacks. Document why Ctrl+C is intentionally swallowed before the existing finally block performs cleanup. Existing non-fatal control flow is preserved.

The FAISS finding on PR #22 is already covered by open PR #24. The additional frame-rejection handler flagged on unmerged PR #27 is not present on main and is outside this diff.

## Test Plan

- 36 analytics tests passed (`python -m pytest tests/test_analytics.py -q`).
- Focused standard-library checks of the actual shutdown and run_forever methods verified that both model closes are attempted after failures, warnings retain exception information, and Ctrl+C calls shutdown.
- Python syntax compilation and AST inspection verified that the only remaining pass-only handler in pipeline.py is the documented KeyboardInterrupt handler.
- Diff whitespace check passed with CRLF recognized as line endings.
- Watchdog tests could not collect because FastAPI is unavailable in the existing environment.

## Checklist

- [x] Changes tested locally
- [x] No secrets or credentials committed
- [x] Updated relevant documentation (inline Ctrl+C explanation)
