### PR TITLE
Frame-flow trace: every receiver decision and every dequeued frame on record (P1 task 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ examples/rc_car_agent/paper/demo2_data/session_*/photos/
 eval/baselines/**/*.log
 eval/baselines/**/*.stdout
 eval/baselines/**/bisect-dual/*/datasheet_raw_*.json
+
+# scripts/benchmark_*.py rewrite the packaged config in place and keep a per-PID backup while a run is live
+rtsm/cfg/rtsm.yaml.*bak*

--- a/rtsm/analytics/latency_analytics.py
+++ b/rtsm/analytics/latency_analytics.py
@@ -297,6 +297,29 @@ class PipelineLatencyBuffer:
                 entries = entries[-last_n:]
             # Grab recent Tier 2 buckets for input_hz estimation
             recent_t2 = [b for b in self._second_buckets if b.frames_in_bucket > 0][-10:]
+            # Lifetime (process-monotonic) counters. Reported cumulatively so a
+            # headless run — no viz client, hence no Tier-2 rollup — still
+            # exposes every drop point.
+            counters = {
+                "received": self._received_count,
+                "processed": total_appended,
+                "gate_rejections": self._gate_rejections,
+                "frame_rejections": self._frame_rejections,
+                "queue_drops": self._queue_drops,
+                "throttle_skips": self._throttle_skips,
+                "tracking_drops": self._tracking_drops,
+            }
+
+        # Lifetime acceptance of DEQUEUED frames by the two pipeline gates
+        # (ingest gate + frame-quality gate), i.e. admitted / (admitted +
+        # gate-rejected + frame-gate-rejected). Lifetime and cumulative, unlike
+        # the windowed rates around it; frames dropped for a failed pose
+        # conversion never reach the gates and are counted on the pipeline
+        # (/stats.pose_conversion_failures), not here. Was hardcoded to 1.0
+        # ("Tier 1 only has accepted frames"), which misled the datasheet: it
+        # read as "nothing was ever gated".
+        dequeued = total_appended + counters["gate_rejections"] + counters["frame_rejections"]
+        gate_acceptance_rate = round(total_appended / dequeued, 4) if dequeued > 0 else 0.0
 
         # For percentile stats, skip warmup frames (only matters early in session)
         # Warmup frames are the first N globally appended, not per-window
@@ -315,7 +338,8 @@ class PipelineLatencyBuffer:
                 "input_hz": 0.0,
                 "processing_hz": 0.0,
                 "effective_ratio": 0.0,
-                "gate_acceptance_rate": 0.0,
+                "gate_acceptance_rate": gate_acceptance_rate,
+                "counters": counters,
                 "t_segmentation": empty_timing,
                 "t_heuristics": empty_timing,
                 "t_scoring": empty_timing,
@@ -345,7 +369,8 @@ class PipelineLatencyBuffer:
             "input_hz": round(input_hz, 1),
             "processing_hz": round(processing_hz, 2),
             "effective_ratio": round(processing_hz / max(0.001, input_hz), 3),
-            "gate_acceptance_rate": 1.0,  # Tier 1 only has accepted frames
+            "gate_acceptance_rate": gate_acceptance_rate,
+            "counters": counters,
             "warmup_skipped": len(entries) - len(entries_for_timing),
             "t_segmentation": _timing_stats([e.t_segmentation for e in entries_for_timing]),
             "t_heuristics": _timing_stats([e.t_heuristics for e in entries_for_timing]),

--- a/rtsm/cfg/rtsm.yaml
+++ b/rtsm/cfg/rtsm.yaml
@@ -369,9 +369,12 @@ analytics:
   retention_s: 3600                 # Tier 2 wall-clock retention (seconds)
   buffer_frames: 300                # Tier 1 per-frame ring buffer size
 
-# -------------------- Eval Diagnostics (Phase 0) --------------------
-# When enabled, writes one JSONL event per processed frame for offline analysis.
-# Each pipeline run gets a FRESH file (no appending across runs).
+# -------------------- Eval Diagnostics (frame-flow trace) --------------------
+# When enabled, writes a JSONL trace for offline analysis: one "receiver" line
+# per receiver decision (enqueued / dropped + reason), one "dequeue" line per
+# dequeued frame (including ingest-gate and frame-quality-gate rejections, with
+# reason and queue wait), and one "frame" line per processed frame. First line is
+# "meta" with schema_version. Each pipeline run gets a FRESH file.
 # Path resolution: see rtsm/evaluation/event_log.py docstring.
 diagnostics:
   enabled: false                  # Master switch. false = zero overhead, no file created.

--- a/rtsm/core/pipeline.py
+++ b/rtsm/core/pipeline.py
@@ -23,7 +23,11 @@ from rtsm.stores.sweep_cache import SweepCache
 from rtsm.io.ingest_queue import IngestQueue
 from rtsm.core.datamodel import FramePacket
 from rtsm.core.watchdog import PipelineHeartbeat
-from rtsm.evaluation.event_log import EventLogWriter, FrameEvent, summarize_sources
+from rtsm.evaluation.event_log import (
+    DQ_DROPPED, DQ_FRAME_REJECTED, DQ_GATE_REJECTED, DQ_PROCESSED,
+    DQ_REASON_GATE_ERROR, DQ_REASON_KEYFRAME, DQ_REASON_NO_POSE, DQ_REASON_POSE_CONVERSION,
+    DequeueEvent, EventLogWriter, FrameEvent, summarize_sources,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -125,6 +129,7 @@ class Pipeline:
         sweep_cache: Optional[SweepCache] = None,
         seg_analytics: Optional[Any] = None,
         latency_analytics: Optional[Any] = None,
+        event_log: Optional[EventLogWriter] = None,
     ):
         self.cfg = cfg
         self.segmenter = segmenter
@@ -159,11 +164,17 @@ class Pipeline:
 
         # Phase 0 diagnostics: per-frame JSONL event log (off by default).
         # See rtsm/evaluation/event_log.py for path resolution rules.
-        diag_cfg = cfg.get("diagnostics", {})
-        self._event_log = EventLogWriter(
-            enabled=bool(diag_cfg.get("enabled", False)),
-            configured_path=diag_cfg.get("event_log_path"),
-        )
+        # The runner passes one writer shared with the receiver thread (the
+        # frame-flow trace); standalone construction (tests, scripts) builds
+        # its own from cfg.diagnostics.
+        if event_log is not None:
+            self._event_log = event_log
+        else:
+            diag_cfg = cfg.get("diagnostics", {})
+            self._event_log = EventLogWriter(
+                enabled=bool(diag_cfg.get("enabled", False)),
+                configured_path=diag_cfg.get("event_log_path"),
+            )
         # Always-present attrs (populated each frame when set; default to None)
         self._last_filter_diagnostics: Optional[FilterDiagnostics] = None
         self._last_scoring_trace: Optional[ScoringTrace] = None
@@ -208,9 +219,11 @@ class Pipeline:
             time.sleep(0.01)
             return
         self.heartbeat.beat_frame()
+        t_deq = time.monotonic()   # dequeue instant for the frame-flow trace (age_s)
 
         # Ingest gate: accept keyframes unconditionally, gate non-KFs with policy
         accept = True
+        gate_reason = DQ_REASON_NO_POSE    # trace label; overwritten by the gate below
         try:
             if pkt is not None and pkt.pose is not None:
                 # compute cell/vbin from pose
@@ -227,7 +240,7 @@ class Pipeline:
                 ts_ns = int(pkt.time.t_sensor_ns or 0)
                 if pkt.is_keyframe:
                     # Update gate's keyframe arrival bookkeeping (grace window) but always accept
-                    _ = self.ingest_gate.should_accept(
+                    dec = self.ingest_gate.should_accept(
                         is_keyframe=True,
                         ts_ns=ts_ns,
                         sweep_cache=self.sweep_cache,
@@ -240,6 +253,7 @@ class Pipeline:
                         now_mono=time.monotonic(),
                     )
                     accept = True
+                    gate_reason = str(getattr(dec, "reason", DQ_REASON_KEYFRAME) or DQ_REASON_KEYFRAME)
                 else:
                     dec = self.ingest_gate.should_accept(
                         is_keyframe=False,
@@ -254,17 +268,21 @@ class Pipeline:
                         now_mono=time.monotonic(),
                     )
                     accept = bool(getattr(dec, 'accept', True))
+                    gate_reason = str(getattr(dec, "reason", "") or "")
             else:
                 accept = True
+                gate_reason = DQ_REASON_NO_POSE
         except Exception as e:
             logger.warning(f"ingest gate error; proceeding: {e}")
             accept = True
+            gate_reason = DQ_REASON_GATE_ERROR
         if not accept:
             if self._latency_analytics:
                 try:
                     self._latency_analytics.record_gate_rejection()
                 except Exception:
                     logger.debug("Failed to record ingest-gate rejection", exc_info=True)
+            self._trace_dequeue(pkt, t_deq, DQ_GATE_REJECTED, gate_reason)
             return
 
         # Frame-quality gate: skip black, blank, or depth-less frames before paying
@@ -282,9 +300,12 @@ class Pipeline:
                 except Exception:
                     pass
             self.frame_gate.maybe_log(fq)
+            self._trace_dequeue(pkt, t_deq, DQ_FRAME_REJECTED, str(getattr(fq, "reason", "") or ""))
             return
+        self._trace_dequeue(pkt, t_deq, DQ_PROCESSED, gate_reason)
 
         t_step_start = time.perf_counter()
+        t_step_start_mono = time.monotonic()   # same clock as the other trace kinds
 
         # 1) segmentation -> masks
         # Ingest frames are BGR by contract (io/websocket.decode_rgb); PIL
@@ -569,7 +590,7 @@ class Pipeline:
                     except Exception:
                         n_conf = 0
                 self._event_log.write(FrameEvent(
-                    timestamp=t_step_start,
+                    timestamp=t_step_start_mono,
                     frame_seq=int(pkt.time.seq or 0) if pkt is not None else 0,
                     is_keyframe=is_kf,
                     n_masks_raw=n_masks,
@@ -578,6 +599,8 @@ class Pipeline:
                     n_matched=m,
                     n_created=c,
                     n_objects_confirmed=n_conf,
+                    t_sensor_ns=(int(pkt.time.t_sensor_ns)
+                                 if pkt is not None and pkt.time.t_sensor_ns is not None else None),
                     timing_ms={
                         "segmentation": (t_seg_end - t_seg_start) * 1000.0,
                         "heuristics": (t_heur_end - t_heur_start) * 1000.0,
@@ -592,6 +615,26 @@ class Pipeline:
                 logger.debug("event log write failed", exc_info=True)
 
     # -------- internals --------
+    def _trace_dequeue(self, pkt: Optional[FramePacket], t_deq: float, outcome: str, reason: str) -> None:
+        """Frame-flow trace: one 'dequeue' line per dequeued frame (no-op when
+        diagnostics are off). Never raises into the processing path."""
+        if not self._event_log.enabled or pkt is None:
+            return
+        try:
+            t_mono = getattr(pkt.time, "t_mono_s", None)
+            self._event_log.write(DequeueEvent(
+                timestamp=t_deq,
+                frame_seq=(int(pkt.time.seq) if pkt.time.seq is not None else None),
+                t_sensor_ns=(int(pkt.time.t_sensor_ns) if pkt.time.t_sensor_ns is not None else None),
+                is_keyframe=bool(pkt.is_keyframe),
+                queue_wait_s=(round(t_deq - float(t_mono), 6) if t_mono is not None else -1.0),
+                queue_depth=(int(self.ingest_q.qsize()) if self.ingest_q is not None else 0),
+                outcome=outcome,
+                reason=reason,
+            ))
+        except Exception:
+            logger.debug("frame-flow trace (dequeue) failed", exc_info=True)
+
     def _get_snapshot_via_queue(self) -> Tuple[Optional[Snapshot], Optional[FramePacket]]:
         if self.ingest_q is None:
             return None, None
@@ -642,6 +685,9 @@ class Pipeline:
                         f"[pipeline] dropping frame: pose present but conversion "
                         f"failed (#{n}): {e}"
                     )
+                # Frame-flow trace: this frame WAS dequeued; record it so the
+                # receiver/dequeue sequences stay in step.
+                self._trace_dequeue(pkt, time.monotonic(), DQ_DROPPED, DQ_REASON_POSE_CONVERSION)
                 return None, None
         return Snapshot(rgb=rgb, depth_m=depth_m, intrinsics=intr, pose_cam_T_world=T), pkt
 

--- a/rtsm/demo.py
+++ b/rtsm/demo.py
@@ -215,6 +215,16 @@ def run_demo(argv: list[str] | None = None) -> None:
         vis_broadcaster = vis_server.broadcaster
         vis_server_registry = vis_server.registry
 
+    # ── Frame-flow trace (diagnostics.*): one writer shared by the replay
+    # thread and the pipeline thread; disabled => every hook is a no-op.
+    from rtsm.evaluation.event_log import EventLogWriter
+    diag_cfg = cfg.get("diagnostics", {}) or {}
+    event_log = EventLogWriter(
+        enabled=bool(diag_cfg.get("enabled", False)),
+        configured_path=diag_cfg.get("event_log_path"),
+    )
+    event_sink = event_log.sink()
+
     # ── Start replay ──
     replay = ReplayReceiver(
         recording_dir=demo_dir,
@@ -229,6 +239,7 @@ def run_demo(argv: list[str] | None = None) -> None:
         on_pose_corrections=vis_server.handle_kf_pose_update if vis_server else None,
         on_pose_corrections_batch=vis_server.handle_pose_corrections_batch if vis_server else None,
         latency_analytics=latency_analytics,
+        event_sink=event_sink,
     )
 
     pipe = Pipeline(
@@ -245,6 +256,7 @@ def run_demo(argv: list[str] | None = None) -> None:
         sweep_cache=sweep_cache,
         seg_analytics=seg_analytics,
         latency_analytics=latency_analytics,
+        event_log=event_log,
     )
 
     # ── Start API + viz WebSocket + static frontend on single port ──
@@ -326,6 +338,7 @@ def run_demo(argv: list[str] | None = None) -> None:
     except KeyboardInterrupt:
         pass
     finally:
+        event_log.close()   # no-op if the pipeline already closed it
         # Print summary
         all_objs = list(wm.iter_objects())
         confirmed = sum(1 for o in all_objs if o.confirmed)

--- a/rtsm/evaluation/__init__.py
+++ b/rtsm/evaluation/__init__.py
@@ -3,8 +3,11 @@ RTSM evaluation utilities — diagnostics, harness, metrics, reports.
 
 See `.claude/plans/permanent-plan/eval-paper-plan-2026.md` for the full plan.
 
-Phase 0 (this module's current scope):
-- event_log: append-only JSONL writer for per-frame diagnostic events.
-  Used together with FilterDiagnostics (rtsm/utils/mask_staging.py) and
-  ScoringTrace (rtsm/core/pipeline.py).
+Current scope:
+- event_log: append-only JSONL frame-flow trace (schema_version 2) — one
+  line per receiver decision, per dequeued frame (gate outcome + reason) and
+  per processed frame (FilterDiagnostics from rtsm/utils/mask_staging.py and
+  ScoringTrace from rtsm/core/pipeline.py). Off by default
+  (cfg.diagnostics.enabled); the record P1's determinism gate and the P2
+  ledgers build on.
 """

--- a/rtsm/evaluation/event_log.py
+++ b/rtsm/evaluation/event_log.py
@@ -1,8 +1,43 @@
 """
-Phase 0 diagnostic event log: append-only JSONL writer.
+Diagnostic event log: append-only JSONL writer (frame-flow trace).
 
-One line per processed frame. Off by default; opt in via cfg.diagnostics.enabled.
-Each pipeline run gets a fresh, auto-timestamped file (no appending across runs).
+Off by default; opt in via cfg.diagnostics.enabled. Each pipeline run gets a
+fresh, auto-timestamped file (no appending across runs). Every line is a JSON
+object with a ``kind`` field; the first line is ``kind: "meta"`` and carries
+``schema_version``.
+
+Line kinds (schema_version 2, 2026-09-09 — P1 task 0 of the Gate 4.5 plan):
+
+  meta      once per file: schema_version, wall time, pid.
+  receiver  one per RECEIVER DECISION (websocket / replay / zeromq thread):
+            enqueued, or dropped with the reason (malformed, parse_error,
+            tracking_state, throttle, duplicate_ts, no_camera_frame,
+            queue_full). Carries the source's seq / t_sensor_ns / is_keyframe
+            when the header parsed. ZeroMQ has no source seq: its join key is
+            (t_sensor_ns, is_keyframe).
+  dequeue   one per DEQUEUED frame (pipeline thread), including the frames the
+            ingest gate or the frame-quality gate rejects and the frames whose
+            present pose fails conversion: outcome (processed | gate_rejected
+            | frame_rejected | dropped), the reason (IngestDecision.reason,
+            FrameGateDecision.reason, "keyframe", "no_pose", "gate_error",
+            "pose_conversion_failed"), and queue_wait_s = dequeue time minus
+            TimeBundle.t_mono_s. That stamp is set when the FramePacket is
+            built (after decode, just before enqueue), so this is the ingest-
+            queue wait; sensor-clock age arrives with the P1 clock work.
+            outcome=processed means ADMITTED to processing: the line is written
+            before segmentation so a crash mid-frame still leaves it; join with
+            the frame line (same t_sensor_ns) for completion.
+  frame     one per PROCESSED frame: masks, filter, scoring, association,
+            timings (the schema_version-1 line, plus kind and t_sensor_ns;
+            timestamp is now time.monotonic() like the other kinds).
+
+A/A comparator contract: compare the receiver and dequeue streams PER KIND as
+ordered sequences of (frame_seq, t_sensor_ns, decision/outcome, reason); never
+compare file order across kinds (an enqueued line is written after put(), so
+the pipeline's dequeue line can precede it), and ignore timestamp,
+queue_wait_s, queue_depth, frame_count and the meta line, which are run-
+specific until the sensor-time clock lands. Writes are serialised with a lock
+because the receiver thread and the pipeline thread both write.
 
 Path resolution rules:
   - None / unset  -> eval_output/<YYYYMMDD_HHMMSS>/events.jsonl  (per-run, auto)
@@ -13,19 +48,46 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import asdict, dataclass, field
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass, field, is_dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
 
+SCHEMA_VERSION = 2
+
+# Receiver decisions
+RX_ENQUEUED = "enqueued"
+RX_DROPPED = "dropped"
+# Receiver drop reasons
+RX_MALFORMED = "malformed"            # truncated / unparseable framing (before or after the header)
+RX_PARSE_ERROR = "parse_error"        # header parsed, but pose / decode / field parsing raised
+RX_TRACKING = "tracking_state"
+RX_THROTTLE = "throttle"
+RX_DUPLICATE_TS = "duplicate_ts"
+RX_NO_CAMERA_FRAME = "no_camera_frame"
+RX_QUEUE_FULL = "queue_full"
+# Dequeue outcomes
+DQ_PROCESSED = "processed"            # admitted to processing (written before segmentation)
+DQ_GATE_REJECTED = "gate_rejected"
+DQ_FRAME_REJECTED = "frame_rejected"
+DQ_DROPPED = "dropped"                # dequeued and discarded before the gates (pose conversion failed)
+# Dequeue reasons that are not an IngestDecision / FrameGateDecision reason
+DQ_REASON_KEYFRAME = "keyframe"
+DQ_REASON_NO_POSE = "no_pose"
+DQ_REASON_GATE_ERROR = "gate_error"
+DQ_REASON_POSE_CONVERSION = "pose_conversion_failed"
+
 
 @dataclass
 class FrameEvent:
-    """One JSONL line. Numbers in milliseconds where named *_ms."""
+    """One line per PROCESSED frame. Numbers in milliseconds where named *_ms."""
     timestamp: float
     frame_seq: int
     is_keyframe: bool
@@ -36,6 +98,37 @@ class FrameEvent:
     n_created: int = 0
     n_objects_confirmed: int = 0
     timing_ms: Dict[str, float] = field(default_factory=dict)
+    t_sensor_ns: Optional[int] = None
+    kind: str = "frame"
+
+
+@dataclass
+class DequeueEvent:
+    """One line per DEQUEUED frame (pipeline thread), rejected or not."""
+    timestamp: float                 # time.monotonic() at dequeue
+    frame_seq: Optional[int]
+    t_sensor_ns: Optional[int]
+    is_keyframe: bool
+    queue_wait_s: float              # dequeue mono - FramePacket.time.t_mono_s (stamped at packet build, ~enqueue)
+    queue_depth: int                 # ingest queue depth right after this dequeue
+    outcome: str                     # processed | gate_rejected | frame_rejected | dropped
+    reason: str                      # gate reason, or one of the DQ_REASON_* labels
+    kind: str = "dequeue"
+
+
+@dataclass
+class ReceiverEvent:
+    """One line per RECEIVER DECISION (websocket / replay / zeromq thread)."""
+    timestamp: float                 # time.monotonic() at the decision
+    source: str                      # websocket | replay | zeromq
+    decision: str                    # enqueued | dropped
+    reason: str                      # "" when enqueued, else the drop reason
+    frame_seq: Optional[int] = None  # source seq (header frame_id) when parsed
+    t_sensor_ns: Optional[int] = None
+    is_keyframe: Optional[bool] = None
+    frame_count: Optional[int] = None  # receiver's running count after the tracking filter
+    queue_depth: Optional[int] = None  # ingest queue depth after the decision
+    kind: str = "receiver"
 
 
 def _json_default(o: Any) -> Any:
@@ -46,6 +139,8 @@ def _json_default(o: Any) -> Any:
         return int(o)
     if isinstance(o, np.ndarray):
         return o.tolist()
+    if isinstance(o, np.bool_):
+        return bool(o)
     raise TypeError(f"not JSON serializable: {type(o).__name__}")
 
 
@@ -66,15 +161,17 @@ def _resolve_path(configured: Optional[str], repo_root: Path) -> Path:
 
 
 class EventLogWriter:
-    """Append-only JSONL writer for per-frame diagnostic events.
+    """Append-only JSONL writer for diagnostic events.
 
-    When `enabled=False`, all calls are zero-cost no-ops.
+    When `enabled=False`, every call is a no-op and `sink()` returns None so
+    producers can skip building events entirely.
     """
 
     def __init__(self, enabled: bool, configured_path: Optional[str], repo_root: Optional[Path] = None):
         self._enabled = bool(enabled)
         self._fh = None
         self._path: Optional[Path] = None
+        self._lock = threading.Lock()
         if not self._enabled:
             return
 
@@ -88,6 +185,13 @@ class EventLogWriter:
         # WRITE mode (truncate) — each run starts fresh. Line-buffered so a
         # crash mid-run still preserves prior frames.
         self._fh = self._path.open("w", encoding="utf-8", buffering=1)
+        self.write({
+            "kind": "meta",
+            "schema_version": SCHEMA_VERSION,
+            "created_wall_utc_s": time.time(),
+            "created_mono_s": time.monotonic(),
+            "pid": os.getpid(),
+        })
         logger.info(f"event_log: writing diagnostics to {self._path}")
 
     @property
@@ -98,17 +202,29 @@ class EventLogWriter:
     def path(self) -> Optional[Path]:
         return self._path
 
-    def write(self, event: FrameEvent) -> None:
+    def write(self, event: Any) -> None:
+        """Write one event (a dataclass or a plain dict). No-op when disabled."""
         if not self._enabled or self._fh is None:
             return
-        self._fh.write(json.dumps(asdict(event), default=_json_default) + "\n")
+        payload = asdict(event) if is_dataclass(event) else dict(event)
+        line = json.dumps(payload, default=_json_default) + "\n"
+        with self._lock:
+            fh = self._fh
+            if fh is not None:
+                fh.write(line)
+
+    def sink(self) -> Optional[Callable[[Any], None]]:
+        """The callable receivers get as `event_sink`: None when disabled."""
+        return self.write if self._enabled else None
 
     def close(self) -> None:
-        if self._fh is not None:
+        with self._lock:
+            fh, self._fh = self._fh, None
+        if fh is not None:
             try:
-                self._fh.close()
-            finally:
-                self._fh = None
+                fh.close()
+            except Exception:  # noqa: BLE001 — closing a log must never raise
+                logger.debug("event_log: close failed", exc_info=True)
 
     def __enter__(self) -> "EventLogWriter":
         return self

--- a/rtsm/io/replayer.py
+++ b/rtsm/io/replayer.py
@@ -17,6 +17,7 @@ from typing import List, Optional
 
 from rtsm.io.ingest_queue import IngestQueue
 from rtsm.io.websocket import WebSocketReceiver
+from rtsm.evaluation.event_log import RX_DROPPED, RX_ENQUEUED, RX_QUEUE_FULL
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ class ReplayReceiver:
         on_pose_corrections_batch: Optional[callable] = None,
         latency_analytics=None,
         replay_speed: float = 1.0,
+        event_sink: Optional[callable] = None,
     ) -> None:
         self._recording_dir = os.path.abspath(recording_dir)
         self._ingest_q = ingest_queue
@@ -78,6 +80,13 @@ class ReplayReceiver:
             on_pose_corrections=on_pose_corrections,
             on_pose_corrections_batch=on_pose_corrections_batch,
             latency_analytics=latency_analytics,  # passed to decoder for frame_received/tracking/throttle hooks
+            # Frame-flow trace: the decoder emits the parse-side decisions
+            # (malformed / parse_error / tracking_state / throttle) tagged
+            # source="replay"; the enqueue decisions are emitted below. Depth
+            # is read from the REAL ingest queue, not the decoder's dummy.
+            event_sink=event_sink,
+            event_source="replay",
+            trace_queue=ingest_queue,
         )
 
         self._replay_speed = max(0.1, replay_speed)  # <1 = slower, >1 = faster
@@ -174,6 +183,7 @@ class ReplayReceiver:
                         ok = self._ingest_q.put(pkt, block=False)
                         if ok:
                             frames_enqueued += 1
+                            self._decoder._trace_rx(RX_ENQUEUED, "", pkt=pkt)
                             # Mirror _handle_stream state update for non-KF throttle
                             if not pkt.is_keyframe:
                                 self._decoder._last_nonkf_enq_mono = time.monotonic()
@@ -186,6 +196,7 @@ class ReplayReceiver:
                             if self._latency_analytics:
                                 self._latency_analytics.record_queue_drop()
                             logger.warning("[replay] ingest queue full; dropping frame")
+                            self._decoder._trace_rx(RX_DROPPED, RX_QUEUE_FULL, pkt=pkt)
 
                 elif kind == "text":
                     try:

--- a/rtsm/io/websocket.py
+++ b/rtsm/io/websocket.py
@@ -31,6 +31,10 @@ from fastapi.responses import JSONResponse
 
 from rtsm.io.ingest_queue import IngestQueue
 from rtsm.utils.transforms import rotmat_to_quat_xyzw
+from rtsm.evaluation.event_log import (
+    RX_DROPPED, RX_ENQUEUED, RX_MALFORMED, RX_PARSE_ERROR, RX_QUEUE_FULL, RX_THROTTLE, RX_TRACKING,
+    ReceiverEvent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -250,8 +254,20 @@ class WebSocketReceiver:
         pose_sink: Optional[callable] = None,
         clearance_sink: Optional[callable] = None,
         latency_analytics: Optional[Any] = None,
+        event_sink: Optional[callable] = None,
+        event_source: str = "websocket",
+        trace_queue: Optional[IngestQueue] = None,
     ) -> None:
         self.ingest_q = ingest_queue
+        # Frame-flow trace: called with a ReceiverEvent for every decision
+        # (enqueued / dropped + reason). None (the default) skips it entirely.
+        # trace_queue: the queue whose depth the lines report (the replayer's
+        # decoder-only instance owns a dummy queue and passes the real one).
+        self._event_sink = event_sink
+        self._event_source = str(event_source)
+        self._trace_queue = trace_queue if trace_queue is not None else ingest_queue
+        self._hdr_seq: Any = None     # header ids of the message being parsed (for parse_error lines)
+        self._hdr_ts: Any = None
         self._host = host
         self._port = port
         self._require_tracking_normal = require_tracking_normal
@@ -435,6 +451,7 @@ class WebSocketReceiver:
                                 ok = self.ingest_q.put(pkt, block=False)
                                 if ok:
                                     frames_enqueued += 1
+                                    self._trace_rx(RX_ENQUEUED, "", pkt=pkt)
                                     self.last_enqueue_mono = time.monotonic()
                                     self._last_enq_ts_ns = pkt.time.t_sensor_ns
                                     if not pkt.is_keyframe:
@@ -455,7 +472,10 @@ class WebSocketReceiver:
                                     logger.warning(
                                         "[websocket] ingest queue full; dropping frame"
                                     )
+                                    self._trace_rx(RX_DROPPED, RX_QUEUE_FULL, pkt=pkt)
                         except Exception as e:
+                            # (the parse_error trace line is emitted inside
+                            # _parse_binary_message, with the header ids)
                             logger.error(f"[websocket] frame parse error: {e}")
                     elif "text" in msg and msg["text"]:
                         # Text message (pose_corrections, etc.)
@@ -540,49 +560,110 @@ class WebSocketReceiver:
             logger.warning(f"[websocket] pose_corrections: unexpected {len(pose_data)} elements, skipping")
             return None
 
+    # ── Frame-flow trace ──
+
+    def _trace_rx(self, decision: str, reason: str = "", *, pkt: Optional[FramePacket] = None,
+                  seq: Any = None, ts: Any = None, is_kf: Optional[bool] = None,
+                  frame_count: Optional[int] = None, queue_depth: Optional[int] = None) -> None:
+        """Emit one ReceiverEvent to the event sink (no-op when unset).
+
+        Returns None so drop sites can `return self._trace_rx(...)`. When a
+        FramePacket is given, its seq / t_sensor_ns / is_keyframe are used.
+        Never raises into the receive path.
+        """
+        sink = self._event_sink
+        if sink is None:
+            return None
+        try:
+            if pkt is not None:
+                seq, ts, is_kf = pkt.time.seq, pkt.time.t_sensor_ns, bool(pkt.is_keyframe)
+                if frame_count is None:
+                    frame_count = self._frame_count
+            if queue_depth is None:
+                q = self._trace_queue
+                queue_depth = int(q.qsize()) if q is not None else None
+            sink(ReceiverEvent(
+                timestamp=time.monotonic(),
+                source=self._event_source,
+                decision=decision,
+                reason=reason,
+                frame_seq=(int(seq) if seq is not None else None),
+                t_sensor_ns=(int(ts) if ts is not None else None),
+                is_keyframe=is_kf,
+                frame_count=frame_count,
+                queue_depth=queue_depth,
+            ))
+        except Exception:
+            logger.debug("[websocket] frame-flow trace failed", exc_info=True)
+        return None
+
     # ── Binary message parsing ──
 
     def _parse_binary_message(self, data: bytes) -> Optional[FramePacket]:
-        """Parse a single binary WebSocket message into a FramePacket."""
+        """Parse a single binary WebSocket message into a FramePacket.
+
+        Thin wrapper around `_parse_binary_message_impl`: when parsing raises
+        after the header was read (malformed T_wc, decode failure, missing
+        field), one 'dropped / parse_error' trace line is emitted with the
+        header ids, then the exception is re-raised so every caller keeps its
+        existing behaviour (the stream loop logs and continues; the replayer
+        propagates as before).
+        """
+        self._hdr_seq = None
+        self._hdr_ts = None
+        try:
+            return self._parse_binary_message_impl(data)
+        except Exception:
+            self._trace_rx(RX_DROPPED, RX_PARSE_ERROR, seq=self._hdr_seq, ts=self._hdr_ts,
+                           frame_count=self._frame_count)
+            raise
+
+    def _parse_binary_message_impl(self, data: bytes) -> Optional[FramePacket]:
         if self._latency_analytics:
             self._latency_analytics.record_frame_received()
 
         offset = 0
         n = len(data)
+        hdr_seq = None   # header frame_id / timestamp_ns for the frame-flow trace
+        hdr_ts = None
 
         # 1. JSON header
         if n < 4:
             logger.warning("[websocket] message too short for json_len")
-            return None
+            return self._trace_rx(RX_DROPPED, RX_MALFORMED)
         (json_len,) = struct.unpack_from("<I", data, offset)
         offset += 4
         if n < offset + json_len:
             logger.warning("[websocket] message truncated at JSON payload")
-            return None
+            return self._trace_rx(RX_DROPPED, RX_MALFORMED)
         header = json.loads(data[offset : offset + json_len].decode("utf-8"))
         offset += json_len
+        if isinstance(header, dict):
+            hdr_seq = header.get("frame_id")
+            hdr_ts = header.get("timestamp_ns")
+        self._hdr_seq, self._hdr_ts = hdr_seq, hdr_ts
 
         # 2. RGB payload
         if n < offset + 4:
             logger.warning("[websocket] message truncated at rgb_len")
-            return None
+            return self._trace_rx(RX_DROPPED, RX_MALFORMED, seq=hdr_seq, ts=hdr_ts)
         (rgb_len,) = struct.unpack_from("<I", data, offset)
         offset += 4
         if n < offset + rgb_len:
             logger.warning("[websocket] message truncated at RGB payload")
-            return None
+            return self._trace_rx(RX_DROPPED, RX_MALFORMED, seq=hdr_seq, ts=hdr_ts)
         rgb_bytes = data[offset : offset + rgb_len]
         offset += rgb_len
 
         # 3. Depth payload
         if n < offset + 4:
             logger.warning("[websocket] message truncated at depth_len")
-            return None
+            return self._trace_rx(RX_DROPPED, RX_MALFORMED, seq=hdr_seq, ts=hdr_ts)
         (depth_len,) = struct.unpack_from("<I", data, offset)
         offset += 4
         if n < offset + depth_len:
             logger.warning("[websocket] message truncated at depth payload")
-            return None
+            return self._trace_rx(RX_DROPPED, RX_MALFORMED, seq=hdr_seq, ts=hdr_ts)
         depth_bytes = data[offset : offset + depth_len]
         offset += depth_len
 
@@ -611,7 +692,7 @@ class WebSocketReceiver:
             logger.info(
                 f"[websocket] dropping frame: tracking_state={tracking_state}"
             )
-            return None
+            return self._trace_rx(RX_DROPPED, RX_TRACKING, seq=hdr_seq, ts=hdr_ts)
 
         # 5b. Parse pose + wall timestamp (hoisted above the keyframe/interval
         # throttle so the pose sink fires at the full input rate).
@@ -663,7 +744,8 @@ class WebSocketReceiver:
             if (now_mono - self._last_nonkf_enq_mono) < self._nonkf_min_interval_s:
                 if self._latency_analytics:
                     self._latency_analytics.record_throttle_skip()
-                return None
+                return self._trace_rx(RX_DROPPED, RX_THROTTLE, seq=hdr_seq, ts=hdr_ts,
+                                      is_kf=False, frame_count=self._frame_count)
 
         # 7. Decode RGB (capture raw JPEG for zero-copy viz forwarding)
         rgb_fmt = header.get("rgb_format", "jpeg")

--- a/rtsm/io/zeromq.py
+++ b/rtsm/io/zeromq.py
@@ -27,6 +27,10 @@ from rtsm.stores.frame_window import FrameWindow
 from rtsm.core.datamodel import FramePacket, TimeBundle, PoseStamped, PinholeIntrinsics
 from rtsm.io.ingest_queue import IngestQueue
 from rtsm.utils.transforms import euler_to_quat_xyzw
+from rtsm.evaluation.event_log import (
+    RX_DROPPED, RX_DUPLICATE_TS, RX_ENQUEUED, RX_MALFORMED, RX_NO_CAMERA_FRAME, RX_QUEUE_FULL, RX_THROTTLE,
+    ReceiverEvent,
+)
 
 
 class ZeroMQSubscriber:
@@ -47,6 +51,7 @@ class ZeroMQSubscriber:
         on_kf_packet: Optional[Callable[..., Any]] = None,
         on_kf_pose_update: Optional[Callable[..., Any]] = None,
         latency_analytics: Optional[Any] = None,
+        event_sink: Optional[Callable[[Any], None]] = None,
     ) -> None:
         """
         Initialize dual-socket ZMQ subscriber.
@@ -115,6 +120,8 @@ class ZeroMQSubscriber:
 
         # Throttle non-keyframe enqueuing (pipeline can't keep up with 30Hz)
         self._last_nonkf_enq_mono: float = 0.0
+        # Frame-flow trace sink (ReceiverEvent per decision); None = off.
+        self._event_sink = event_sink
         self._nonkf_min_interval_s: float = 0.5  # Max ~2 non-KF per second
 
         # Frame-flow liveness stamps (read by the watchdog). The subscriber
@@ -248,6 +255,7 @@ class ZeroMQSubscriber:
         """
         if len(parts) != 2:
             logger.warning(f"[zeromq] tracking_pose: expected 2 parts, got {len(parts)}")
+            self._trace_rx(RX_DROPPED, RX_MALFORMED, None, False)
             return
 
         try:
@@ -265,6 +273,7 @@ class ZeroMQSubscriber:
 
         except Exception as e:
             logger.error(f"[zeromq] tracking_pose: parse error: {e}")
+            self._trace_rx(RX_DROPPED, RX_MALFORMED, None, False)
 
     def _handle_kf_pose(self, parts: List[bytes]) -> None:
         """
@@ -276,6 +285,7 @@ class ZeroMQSubscriber:
         """
         if len(parts) != 2:
             logger.warning(f"[zeromq] kf_pose: expected 2 parts, got {len(parts)}")
+            self._trace_rx(RX_DROPPED, RX_MALFORMED, None, True)
             return
 
         try:
@@ -291,6 +301,7 @@ class ZeroMQSubscriber:
 
         except Exception as e:
             logger.error(f"[zeromq] kf_pose: parse error: {e}")
+            self._trace_rx(RX_DROPPED, RX_MALFORMED, None, True)
 
     def _handle_kf_packet(self, parts: List[bytes]) -> None:
         """
@@ -468,6 +479,7 @@ class ZeroMQSubscriber:
 
         # Skip duplicates (except keyframes always get enqueued)
         if not is_keyframe and self._last_enq_ts_ns == ts_ns:
+            self._trace_rx(RX_DROPPED, RX_DUPLICATE_TS, ts_ns, is_keyframe)
             return
 
         # Throttle non-keyframes to avoid overwhelming the pipeline
@@ -475,12 +487,14 @@ class ZeroMQSubscriber:
         if not is_keyframe:
             elapsed = now_mono - self._last_nonkf_enq_mono
             if elapsed < self._nonkf_min_interval_s:
+                self._trace_rx(RX_DROPPED, RX_THROTTLE, ts_ns, is_keyframe)
                 return  # Skip, too soon since last non-KF
 
         # Assemble frame data from window
         rgb, depth, intr = self.fw.assemble_pair(ts_ns)
         if rgb is None:
             # No matching camera frame yet
+            self._trace_rx(RX_DROPPED, RX_NO_CAMERA_FRAME, ts_ns, is_keyframe)
             return
 
         # Build pose
@@ -520,11 +534,36 @@ class ZeroMQSubscriber:
                 self._last_nonkf_enq_mono = now_mono
             frame_type = "KF" if is_keyframe else "frame"
             logger.debug(f"[zmq] enqueued {frame_type} -> queue={self.ingest_q.qsize()}")
+            self._trace_rx(RX_ENQUEUED, "", ts_ns, is_keyframe)
         else:
             if self._latency_analytics:
                 self._latency_analytics.record_queue_drop()
             frame_type = "keyframe" if is_keyframe else "non-KF"
             logger.warning(f"[zeromq] ingest queue full; dropping {frame_type}")
+            self._trace_rx(RX_DROPPED, RX_QUEUE_FULL, ts_ns, is_keyframe)
+
+    def _trace_rx(self, decision: str, reason: str, ts_ns: Optional[int], is_keyframe: bool) -> None:
+        """Frame-flow trace: one ReceiverEvent per receiver decision (no-op when
+        no sink is set). ZeroMQ has no source seq; (t_sensor_ns, is_keyframe)
+        is the join key. Never raises into the receive path."""
+        sink = self._event_sink
+        if sink is None:
+            return
+        try:
+            q = self.ingest_q
+            sink(ReceiverEvent(
+                timestamp=time.monotonic(),
+                source="zeromq",
+                decision=decision,
+                reason=reason,
+                frame_seq=None,
+                t_sensor_ns=(int(ts_ns) if ts_ns is not None else None),
+                is_keyframe=bool(is_keyframe),
+                frame_count=None,
+                queue_depth=(int(q.qsize()) if q is not None else None),
+            ))
+        except Exception:
+            logger.debug("[zeromq] frame-flow trace failed", exc_info=True)
 
     def liveness(self) -> dict:
         """Frame-flow liveness snapshot for the watchdog."""

--- a/rtsm/run.py
+++ b/rtsm/run.py
@@ -34,6 +34,7 @@ from rtsm.api.server import create_app, start_server, ResetComponents
 from rtsm.cfg import ConfigError, cfg_path, config_fingerprint
 from rtsm.cfg.cli import add_config_arguments, config_from_args
 from rtsm.cfg.tuning import validate_tuning
+from rtsm.evaluation.event_log import EventLogWriter
 
 import argparse
 import sys
@@ -251,6 +252,16 @@ def main():
             "only the live websocket receiver computes it (replay=%s, receiver=%s); "
             "/stats.forward_clearance will stay null", bool(args.replay), receiver_type)
 
+    # Frame-flow trace (diagnostics.*): one JSONL writer shared by the receiver
+    # thread and the pipeline thread. Disabled (the default) => every hook is a
+    # no-op and event_sink is None, so receivers skip building events entirely.
+    diag_cfg = cfg.get("diagnostics", {}) or {}
+    event_log = EventLogWriter(
+        enabled=bool(diag_cfg.get("enabled", False)),
+        configured_path=diag_cfg.get("event_log_path"),
+    )
+    event_sink = event_log.sink()
+
     # Will be set to FrameWindow or None depending on receiver
     frame_window_for_reset = None
 
@@ -271,6 +282,7 @@ def main():
             on_pose_corrections_batch=vis_server.handle_pose_corrections_batch if vis_server else None,
             latency_analytics=latency_analytics,
             replay_speed=args.replay_speed,
+            event_sink=event_sink,
         )
         replay_receiver.start()
         logger.info(f"Replay receiver started from {args.replay} (speed={args.replay_speed}x)")
@@ -305,6 +317,7 @@ def main():
             # io.clearance.enable (see clearance_enabled above); None makes
             # the receiver skip the depth statistic entirely.
             clearance_sink=wm.set_forward_clearance if clearance_enabled else None,
+            event_sink=event_sink,
             latency_analytics=latency_analytics,
         )
         ws_receiver.start()
@@ -323,6 +336,7 @@ def main():
             pose_m_per_unit=float(units_cfg.get("pose_m_per_unit", 1.0)),
             on_kf_packet=vis_server.handle_kf_packet if vis_server else None,
             on_kf_pose_update=vis_server.handle_kf_pose_update if vis_server else None,
+            event_sink=event_sink,
             latency_analytics=latency_analytics,
         )
         t = threading.Thread(target=sub.run_forever, daemon=True)
@@ -352,6 +366,7 @@ def main():
         vectors=vectors,
         ingest_q=ingest_q,
         sweep_cache=sweep_cache,
+        event_log=event_log,
         seg_analytics=seg_analytics,
         latency_analytics=latency_analytics,
     )
@@ -484,6 +499,7 @@ def main():
     finally:
         if recorder is not None:
             recorder.close()
+        event_log.close()   # no-op if the pipeline already closed it
 
 if __name__ == "__main__":
     main()

--- a/tests/test_frame_flow_trace.py
+++ b/tests/test_frame_flow_trace.py
@@ -1,0 +1,450 @@
+"""Frame-flow trace (Gate 4.5 plan, P1 task 0): every receiver decision and every
+dequeued frame leaves a line in the diagnostic event log; gate_acceptance_rate is
+computed, not hard-coded. Everything here runs CPU-only, no models, no sockets
+beyond a ZeroMQ SUB connect to a port nobody listens on.
+"""
+from __future__ import annotations
+
+import json
+import struct
+import threading
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from rtsm.analytics.latency_analytics import FrameTimingStats, PipelineLatencyBuffer
+from rtsm.core.datamodel import FramePacket, PoseStamped, TimeBundle
+from rtsm.core.ingest_gate import IngestDecision
+from rtsm.core.pipeline import Pipeline
+from rtsm.evaluation.event_log import (
+    SCHEMA_VERSION, DequeueEvent, EventLogWriter, FrameEvent, ReceiverEvent,
+)
+from rtsm.io.ingest_queue import IngestQueue
+from rtsm.io.websocket import WebSocketReceiver
+
+
+# ───────────────────────────── helpers ─────────────────────────────
+
+def _lines(path: Path):
+    return [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def _writer(tmp_path: Path) -> EventLogWriter:
+    return EventLogWriter(enabled=True, configured_path=str(tmp_path / "events.jsonl"))
+
+
+def _pose() -> PoseStamped:
+    return PoseStamped(stamp_ns=0, frame_id="arkit",
+                       t_wc=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+                       q_wc_xyzw=np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32))
+
+
+def _packet(*, seq: int = 7, ts_ns: int = 123_000_000, is_kf: bool = False,
+            t_mono: float = 0.0, pose=None) -> FramePacket:
+    return FramePacket(
+        rgb=np.zeros((8, 8, 3), dtype=np.uint8),
+        depth_m=np.ones((8, 8), dtype=np.float32),
+        pose=_pose() if pose is None else pose,
+        intr=None,
+        is_keyframe=is_kf,
+        time=TimeBundle(t_mono_s=t_mono, t_wall_utc_s=0.0, t_sensor_ns=ts_ns, seq=seq),
+    )
+
+
+class _GateStub:
+    """IngestGate stand-in: returns a scripted decision, records the calls."""
+
+    def __init__(self, accept: bool, reason: str):
+        self._dec = IngestDecision(accept, reason)
+        self.calls = 0
+
+    def should_accept(self, **_kw) -> IngestDecision:
+        self.calls += 1
+        return self._dec
+
+
+class _SweepCacheStub:
+    def cell_and_vbin_from_pose(self, *, twc_xyz, q_wc_xyzw):
+        return (0, 0, 0), 0, np.array([0.0, 0.0, 1.0], dtype=np.float32)
+
+
+def _accept_all_frames(pipe: Pipeline) -> None:
+    """Neutralise the frame-quality gate (synthetic frames are black)."""
+    class _Ok:
+        accept, reason = True, ""
+    pipe.frame_gate.check = lambda rgb, depth: _Ok()     # type: ignore[assignment]
+    pipe.frame_gate.maybe_log = lambda d: None           # type: ignore[assignment]
+
+
+def _pipeline(q: IngestQueue, gate, event_log: EventLogWriter) -> Pipeline:
+    return Pipeline(cfg={}, segmenter=None, clip=None, working_mem=None, proximity_index=None,
+                    associator=None, ingest_gate=gate, ingest_q=q,
+                    sweep_cache=_SweepCacheStub(), event_log=event_log)
+
+
+def _ws_frame(**overrides) -> bytes:
+    rgb = np.zeros((16, 16, 3), dtype=np.uint8)
+    _, jpeg = cv2.imencode(".jpg", rgb)
+    depth = (np.ones((16, 16), dtype=np.uint16) * 1500).tobytes()
+    header = {
+        "frame_id": 11, "timestamp_ns": 5_000_000_000, "unix_timestamp": 1700000000.0,
+        "rgb_format": "jpeg", "rgb_width": 16, "rgb_height": 16,
+        "depth_format": "uint16_mm", "depth_width": 16, "depth_height": 16, "depth_scale": 0.001,
+        "fx": 10.0, "fy": 10.0, "cx": 8.0, "cy": 8.0,
+        "pose_format": "quat_translation", "T_wc": [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        "tracking_state": "normal",
+    }
+    header.update(overrides)
+    hj = json.dumps(header).encode("utf-8")
+    rj = jpeg.tobytes()
+    return (struct.pack("<I", len(hj)) + hj + struct.pack("<I", len(rj)) + rj
+            + struct.pack("<I", len(depth)) + depth)
+
+
+# ───────────────────────────── writer ─────────────────────────────
+
+class TestEventLogWriter:
+    def test_disabled_is_a_noop_and_has_no_sink(self, tmp_path):
+        w = EventLogWriter(enabled=False, configured_path=str(tmp_path / "never.jsonl"))
+        assert w.sink() is None
+        w.write({"kind": "x"})
+        w.write(ReceiverEvent(timestamp=0.0, source="websocket", decision="dropped", reason="throttle"))
+        w.close()
+        assert not (tmp_path / "never.jsonl").exists()
+
+    def test_meta_line_then_typed_lines(self, tmp_path):
+        w = _writer(tmp_path)
+        assert w.sink() is not None
+        w.write(ReceiverEvent(timestamp=1.0, source="replay", decision="enqueued", reason="",
+                              frame_seq=3, t_sensor_ns=30, is_keyframe=True, frame_count=1, queue_depth=1))
+        w.write(DequeueEvent(timestamp=2.0, frame_seq=3, t_sensor_ns=30, is_keyframe=True, queue_wait_s=0.5,
+                             queue_depth=0, outcome="processed", reason="keyframe"))
+        w.write(FrameEvent(timestamp=3.0, frame_seq=3, is_keyframe=True, n_masks_raw=4, t_sensor_ns=30))
+        w.close()
+        rows = _lines(w.path)
+        assert [r["kind"] for r in rows] == ["meta", "receiver", "dequeue", "frame"]
+        assert rows[0]["schema_version"] == SCHEMA_VERSION
+        assert rows[1]["decision"] == "enqueued" and rows[1]["source"] == "replay"
+        assert rows[2]["outcome"] == "processed" and rows[2]["queue_wait_s"] == 0.5
+        assert rows[3]["t_sensor_ns"] == 30
+
+    def test_concurrent_writers_keep_lines_intact(self, tmp_path):
+        w = _writer(tmp_path)
+
+        def worker(tag: str):
+            for i in range(300):
+                w.write({"kind": "t", "tag": tag, "i": i, "pad": "x" * 200})
+
+        ts = [threading.Thread(target=worker, args=(f"w{k}",)) for k in range(4)]
+        [t.start() for t in ts]
+        [t.join() for t in ts]
+        w.close()
+        rows = _lines(w.path)          # json.loads on every line = no interleaving
+        assert len(rows) == 1 + 4 * 300
+
+
+# ───────────────────────────── pipeline: dequeue lines ─────────────────────────────
+
+class TestDequeueTrace:
+    def test_gate_rejection_writes_reason_and_age(self, tmp_path):
+        w = _writer(tmp_path)
+        q = IngestQueue()
+        pipe = _pipeline(q, _GateStub(False, "ttl_not_expired"), w)
+        q.put(_packet(seq=41, ts_ns=41_000, is_kf=False, t_mono=0.0))
+        pipe.run_one_step()                       # returns at the ingest gate
+        w.close()
+        deq = [r for r in _lines(w.path) if r["kind"] == "dequeue"]
+        assert len(deq) == 1
+        r = deq[0]
+        assert r["outcome"] == "gate_rejected" and r["reason"] == "ttl_not_expired"
+        assert r["frame_seq"] == 41 and r["t_sensor_ns"] == 41_000 and r["is_keyframe"] is False
+        assert r["queue_wait_s"] > 0.0                   # arrival t_mono 0.0 vs a live monotonic dequeue
+        assert r["queue_depth"] == 0
+
+    def test_frame_gate_rejection_writes_frame_rejected(self, tmp_path):
+        w = _writer(tmp_path)
+        q = IngestQueue()
+        pipe = _pipeline(q, _GateStub(True, "keyframe"), w)
+
+        class _Reject:
+            accept, reason = False, "dark"
+
+        pipe.frame_gate.check = lambda rgb, depth: _Reject()   # type: ignore[assignment]
+        pipe.frame_gate.maybe_log = lambda d: None             # type: ignore[assignment]
+        q.put(_packet(seq=5, is_kf=True))
+        pipe.run_one_step()
+        w.close()
+        deq = [r for r in _lines(w.path) if r["kind"] == "dequeue"]
+        assert [(r["outcome"], r["reason"]) for r in deq] == [("frame_rejected", "dark")]
+
+    def test_accepted_frame_is_traced_before_processing(self, tmp_path):
+        """The 'processed' line is written before segmentation starts, so a
+        crash inside processing still leaves the dequeue record. With
+        segmenter=None the step raises right after the trace."""
+        w = _writer(tmp_path)
+        q = IngestQueue()
+        pipe = _pipeline(q, _GateStub(True, "keyframe"), w)
+        _accept_all_frames(pipe)                  # the synthetic frame is black; keep the quality gate out of it
+        q.put(_packet(seq=9, ts_ns=9_000, is_kf=True))
+        with pytest.raises(AttributeError, match="segment"):
+            pipe.run_one_step()
+        w.close()
+        deq = [r for r in _lines(w.path) if r["kind"] == "dequeue"]
+        assert [(r["outcome"], r["reason"], r["frame_seq"]) for r in deq] == [("processed", "keyframe", 9)]
+
+    def test_no_pose_frame_is_labelled_no_pose(self, tmp_path):
+        w = _writer(tmp_path)
+        q = IngestQueue()
+        gate = _GateStub(False, "would_reject")
+        pipe = _pipeline(q, gate, w)
+        _accept_all_frames(pipe)
+        pkt = FramePacket(rgb=np.zeros((8, 8, 3), dtype=np.uint8), depth_m=None, pose=None, intr=None,
+                          is_keyframe=False, time=TimeBundle(t_mono_s=0.0, t_wall_utc_s=0.0, t_sensor_ns=1, seq=2))
+        q.put(pkt)
+        with pytest.raises(AttributeError, match="segment"):            # pose-less frames bypass the gate and go on to (absent) segmentation
+            pipe.run_one_step()
+        w.close()
+        deq = [r for r in _lines(w.path) if r["kind"] == "dequeue"]
+        assert deq and deq[0]["outcome"] == "processed" and deq[0]["reason"] == "no_pose"
+        assert gate.calls == 0
+
+    def test_disabled_log_costs_nothing_and_changes_nothing(self, tmp_path):
+        w = EventLogWriter(enabled=False, configured_path=str(tmp_path / "off.jsonl"))
+        q = IngestQueue()
+        gate = _GateStub(False, "ttl_not_expired")
+        pipe = _pipeline(q, gate, w)
+        q.put(_packet())
+        pipe.run_one_step()
+        assert gate.calls == 1
+        assert not (tmp_path / "off.jsonl").exists()
+
+    def test_pose_conversion_failure_is_a_dropped_dequeue_line(self, tmp_path):
+        """A present-but-corrupt pose is dropped inside _get_snapshot_via_queue
+        (PR #23). It WAS dequeued, so the trace must say so, or the receiver
+        and dequeue sequences drift apart."""
+        class _RaisingPose:
+            t_wc = np.array([0.0, 0.0, 0.0], dtype=np.float32)
+
+            def T_wc(self):
+                raise ValueError("corrupt pose payload")
+
+        w = _writer(tmp_path)
+        q = IngestQueue()
+        gate = _GateStub(True, "keyframe")
+        pipe = _pipeline(q, gate, w)
+        q.put(_packet(seq=13, ts_ns=13_000, is_kf=True, pose=_RaisingPose()))
+        pipe.run_one_step()                       # dropped before the gates; no exception
+        w.close()
+        deq = [r for r in _lines(w.path) if r["kind"] == "dequeue"]
+        assert [(r["outcome"], r["reason"], r["frame_seq"], r["t_sensor_ns"]) for r in deq] == [
+            ("dropped", "pose_conversion_failed", 13, 13_000)]
+        assert pipe.pose_conversion_failures == 1 and gate.calls == 0
+
+    def test_pipeline_builds_its_own_writer_when_none_is_passed(self):
+        q = IngestQueue()
+        pipe = Pipeline(cfg={}, segmenter=None, clip=None, working_mem=None, proximity_index=None,
+                        associator=None, ingest_gate=None, ingest_q=q)
+        assert pipe._event_log.enabled is False
+
+
+# ───────────────────────────── receivers ─────────────────────────────
+
+class TestReceiverTrace:
+    def _recv(self, sink, **kw) -> WebSocketReceiver:
+        return WebSocketReceiver(ingest_queue=IngestQueue(maxsize=4), keyframe_every_n=30,
+                                 nonkf_min_interval_s=kw.pop("nonkf_min_interval_s", 0.5),
+                                 event_sink=sink, **kw)
+
+    def test_no_sink_means_no_events_and_same_parse_result(self):
+        recv = WebSocketReceiver(ingest_queue=IngestQueue(maxsize=4), keyframe_every_n=30)
+        assert recv._event_sink is None
+        assert recv._parse_binary_message(_ws_frame()) is not None
+        assert recv._parse_binary_message(b"\x00\x00") is None
+
+    def test_malformed_before_header_has_no_seq(self):
+        events = []
+        recv = self._recv(events.append)
+        assert recv._parse_binary_message(b"\x00\x00") is None
+        assert len(events) == 1
+        e = events[0]
+        assert (e.decision, e.reason, e.frame_seq, e.t_sensor_ns, e.source) == ("dropped", "malformed", None, None, "websocket")
+
+    def test_tracking_state_drop_carries_header_ids(self):
+        events = []
+        recv = self._recv(events.append)
+        assert recv._parse_binary_message(_ws_frame(tracking_state="limited", frame_id=77, timestamp_ns=777)) is None
+        assert [(e.decision, e.reason, e.frame_seq, e.t_sensor_ns) for e in events] == [("dropped", "tracking_state", 77, 777)]
+
+    def test_throttle_drop_is_traced_with_frame_count(self):
+        events = []
+        recv = self._recv(events.append, nonkf_min_interval_s=10.0)
+        assert recv._parse_binary_message(_ws_frame(frame_id=1)) is not None     # frame 1 = keyframe, decoded
+        import time as _t
+        recv._last_nonkf_enq_mono = _t.monotonic()                              # as if the KF had just been enqueued
+        assert recv._parse_binary_message(_ws_frame(frame_id=2, timestamp_ns=2)) is None
+        thr = [e for e in events if e.reason == "throttle"]
+        assert len(thr) == 1
+        assert (thr[0].decision, thr[0].frame_seq, thr[0].is_keyframe, thr[0].frame_count) == ("dropped", 2, False, 2)
+
+    def test_decoded_frames_emit_nothing_at_parse_time(self):
+        """The enqueue decision belongs to the caller (stream loop / replayer),
+        so a successful parse must not pre-empt it with an event."""
+        events = []
+        recv = self._recv(events.append)
+        assert recv._parse_binary_message(_ws_frame()) is not None
+        assert events == []
+
+    def test_event_source_label_and_queue_depth_override(self):
+        events = []
+        recv = WebSocketReceiver(ingest_queue=IngestQueue(maxsize=4), event_sink=events.append, event_source="replay")
+        pkt = recv._parse_binary_message(_ws_frame(frame_id=3, timestamp_ns=33))
+        recv._trace_rx("enqueued", "", pkt=pkt, queue_depth=17)
+        e = events[-1]
+        assert (e.source, e.decision, e.frame_seq, e.t_sensor_ns, e.is_keyframe, e.queue_depth) == ("replay", "enqueued", 3, 33, True, 17)
+
+    def test_parse_error_after_header_carries_ids_and_reraises(self):
+        """A malformed T_wc raises out of the parser exactly as before, but now
+        leaves one 'parse_error' line with the header ids and frame_count."""
+        events = []
+        recv = self._recv(events.append)
+        with pytest.raises(Exception):
+            recv._parse_binary_message(_ws_frame(frame_id=21, timestamp_ns=2100, T_wc=[1.0, 2.0, 3.0]))
+        assert len(events) == 1
+        e = events[0]
+        assert (e.decision, e.reason, e.frame_seq, e.t_sensor_ns, e.frame_count) == ("dropped", "parse_error", 21, 2100, 0)
+
+    def test_non_object_header_is_malformed_not_a_crash(self):
+        events = []
+        recv = self._recv(events.append)
+        hj = json.dumps([1, 2, 3]).encode("utf-8")
+        msg = struct.pack("<I", len(hj)) + hj + b"\x00\x00"        # list header + truncated body
+        assert recv._parse_binary_message(msg) is None
+        assert [(e.decision, e.reason, e.frame_seq) for e in events] == [("dropped", "malformed", None)]
+
+    def test_sink_errors_never_break_the_receive_path(self):
+        def boom(_e):
+            raise RuntimeError("sink down")
+        recv = self._recv(boom)
+        assert recv._parse_binary_message(b"\x00\x00") is None
+        assert recv._parse_binary_message(_ws_frame()) is not None
+
+
+class TestReplayTrace:
+    def test_replay_lines_are_tagged_and_read_the_real_queue(self, tmp_path):
+        """Three recorded frames: frame 1 is a keyframe (enqueued), frame 2 a
+        non-KF (enqueued), frame 3 a non-KF inside the 0.5 s throttle window
+        (dropped). Lines carry source='replay' and the REAL queue's depth."""
+        from rtsm.io.recorder import SessionRecorder
+        from rtsm.io.replayer import ReplayReceiver
+
+        rec_dir = tmp_path / "rec"
+        rec = SessionRecorder(output_dir=str(rec_dir))
+        for i in (1, 2, 3):
+            rec.on_message("binary", _ws_frame(frame_id=i, timestamp_ns=i * 1000))
+        rec.on_handshake({"type": "hello", "session_id": "s1"}, {"type": "hello_ack", "status": "ok"})
+        rec.close()
+
+        events = []
+        q = IngestQueue(maxsize=8)
+        rr = ReplayReceiver(recording_dir=str(rec_dir), ingest_queue=q, keyframe_every_n=30,
+                            nonkf_min_interval_s=0.5, event_sink=events.append, replay_speed=10.0)
+        rr.start()
+        assert rr._done.wait(10.0), "replay did not finish"
+        got = [(e.source, e.decision, e.reason, e.frame_seq, e.is_keyframe, e.queue_depth) for e in events]
+        assert got == [
+            ("replay", "enqueued", "", 1, True, 1),
+            ("replay", "enqueued", "", 2, False, 2),
+            ("replay", "dropped", "throttle", 3, False, 2),
+        ]
+        assert q.qsize() == 2
+
+
+class TestZeroMQTrace:
+    def test_enqueue_decisions_are_traced(self):
+        zmq = pytest.importorskip("zmq")
+        from rtsm.io.zeromq import ZeroMQSubscriber
+
+        events = []
+        q = IngestQueue(maxsize=1)
+        sub = ZeroMQSubscriber(camera_endpoint="tcp://127.0.0.1:1", rtabmap_endpoint="tcp://127.0.0.1:1",
+                               ingest_queue=q, event_sink=events.append)
+        try:
+            sub._nonkf_min_interval_s = 0.0
+            rgb = np.zeros((4, 4, 3), dtype=np.uint8)
+            depth = np.ones((4, 4), dtype=np.float32)
+
+            class _FW:
+                def __init__(self):
+                    self.has = True
+
+                def assemble_pair(self, ts_ns):
+                    return (rgb, depth, None) if self.has else (None, None, None)
+
+            sub.fw = _FW()
+            t = np.zeros(3, dtype=np.float32)
+            qq = np.array([0, 0, 0, 1], dtype=np.float32)
+            sub._try_enqueue_frame(100, t, qq, is_keyframe=True)      # enqueued (queue now full)
+            sub._try_enqueue_frame(101, t, qq, is_keyframe=True)      # queue_full
+            sub._try_enqueue_frame(100, t, qq, is_keyframe=False)     # duplicate_ts (last enqueued ts)
+            sub.fw.has = False
+            sub._try_enqueue_frame(102, t, qq, is_keyframe=False)     # no_camera_frame
+            got = [(e.source, e.decision, e.reason, e.t_sensor_ns, e.is_keyframe) for e in events]
+            assert got == [
+                ("zeromq", "enqueued", "", 100, True),
+                ("zeromq", "dropped", "queue_full", 101, True),
+                ("zeromq", "dropped", "duplicate_ts", 100, False),
+                ("zeromq", "dropped", "no_camera_frame", 102, False),
+            ]
+        finally:
+            sub.close()
+
+    def test_malformed_pose_messages_are_traced(self):
+        pytest.importorskip("zmq")
+        from rtsm.io.zeromq import ZeroMQSubscriber
+
+        events = []
+        sub = ZeroMQSubscriber(camera_endpoint="tcp://127.0.0.1:1", rtabmap_endpoint="tcp://127.0.0.1:1",
+                               ingest_queue=IngestQueue(maxsize=4), event_sink=events.append)
+        try:
+            sub._handle_tracking_pose([b"rtabmap.tracking_pose"])             # wrong part count
+            sub._handle_kf_pose([b"rtabmap.kf_pose", b"not json at all"])     # parse error
+            assert [(e.decision, e.reason, e.is_keyframe, e.t_sensor_ns) for e in events] == [
+                ("dropped", "malformed", False, None),
+                ("dropped", "malformed", True, None),
+            ]
+        finally:
+            sub.close()
+
+
+# ───────────────────────────── analytics ─────────────────────────────
+
+class TestGateAcceptanceRate:
+    def test_rate_and_counters_are_computed_from_lifetime_counts(self):
+        buf = PipelineLatencyBuffer(max_frames=50)
+        for _ in range(3):
+            buf.record_frame_received()
+        for i in range(6):
+            buf.append(FrameTimingStats(timestamp=float(i)))
+        buf.record_gate_rejection(); buf.record_gate_rejection(); buf.record_gate_rejection()
+        buf.record_frame_rejection()
+        buf.record_throttle_skip(); buf.record_queue_drop(); buf.record_tracking_drop()
+        agg = buf.aggregate()
+        # 6 processed out of 6 + 3 + 1 dequeued
+        assert agg["gate_acceptance_rate"] == pytest.approx(0.6)
+        assert agg["counters"] == {
+            "received": 3, "processed": 6, "gate_rejections": 3, "frame_rejections": 1,
+            "queue_drops": 1, "throttle_skips": 1, "tracking_drops": 1,
+        }
+
+    def test_rate_is_zero_when_nothing_was_dequeued(self):
+        buf = PipelineLatencyBuffer(max_frames=50)
+        agg = buf.aggregate()
+        assert agg["frame_count"] == 0 and agg["gate_acceptance_rate"] == 0.0
+        assert agg["counters"]["processed"] == 0
+
+    def test_all_rejected_reads_zero_not_one(self):
+        buf = PipelineLatencyBuffer(max_frames=50)
+        buf.record_gate_rejection()
+        assert buf.aggregate()["gate_acceptance_rate"] == 0.0


### PR DESCRIPTION
# Frame-flow trace: every receiver decision and every dequeued frame on record (P1 task 0)

Execution plan `execution-plan-gate45-2026-09.md`, P1 task 0. One behaviour-neutral commit that gives P1's determinism gate (G1-B: "two runs give an identical dequeued sequence and identical gate reasons") the record it needs, and fixes a misleading metric.

## What changes

- **`rtsm/evaluation/event_log.py`** — schema_version 2. Every line carries `kind`; the first line is `meta`. New line kinds beside the existing per-processed-frame `frame` line:
  - `receiver`: one per receiver decision on the websocket / replay / zeromq thread — `enqueued`, or `dropped` with the reason (`malformed`, `parse_error`, `tracking_state`, `throttle`, `duplicate_ts`, `no_camera_frame`, `queue_full`), with the source `frame_seq`, `t_sensor_ns`, `is_keyframe`, the receiver's `frame_count` and the queue depth. `parse_error` lines (a T_wc that fails to parse, a decode failure) carry the header ids: `_parse_binary_message` is now a thin wrapper that traces and re-raises, so callers behave exactly as before. ZeroMQ malformed pose messages are traced too; ZeroMQ has no source seq, its join key is `(t_sensor_ns, is_keyframe)`.
  - `dequeue`: one per dequeued frame on the pipeline thread, including the frames the ingest gate or the frame-quality gate rejects and the frames whose present pose fails conversion (PR #23's drop path) — `outcome` (`processed` | `gate_rejected` | `frame_rejected` | `dropped`), the `reason` (the `IngestDecision.reason`: `keyframe`, `skip`, `hard_max_s`, `parallax`, `near_recent_keyframe`, `non_kf_grace`, …; the `FrameGateDecision.reason`: `dark` / `flat` / `depth`; `no_pose`; `gate_error`; `pose_conversion_failed`), `queue_wait_s` = dequeue time minus the packet's build stamp (set after decode, just before enqueue, so it is the ingest-queue wait; sensor-clock age comes with the P1 clock work), and the queue depth after dequeue. `processed` means admitted: the line is written before segmentation, so a crash mid-frame still leaves it.
  - `frame` gains `t_sensor_ns` so it joins with the other two, and its `timestamp` moves to the same monotonic clock as the other kinds (it was `perf_counter`).
  - The module docstring states the A/A comparator contract: compare per-kind sequences of `(frame_seq, t_sensor_ns, decision/outcome, reason)`, never file order; timestamps, waits, depths and the meta line are run-specific.
  - Writes are serialised with a lock (two producer threads); `sink()` returns `None` when disabled so producers skip building events entirely.
- **Receivers** (`websocket.py`, `replayer.py`, `zeromq.py`) take an optional `event_sink`; every early return and every enqueue site emits exactly one line, using the `RX_*` constants from `event_log.py`. The replayer's decoder is tagged `source="replay"` and reads depth from the real ingest queue (`trace_queue=`), not its dummy.
- **`pipeline.py`** takes an optional shared `event_log` (falls back to building its own, so `Pipeline(cfg={})` in tests is unchanged), captures the gate reason on the accept path too (the keyframe branch discarded it), and emits the `dequeue` line at the three exits before segmentation.
- **`run.py` / `demo.py`** build one writer from `diagnostics.*` and hand it to the pipeline and the receivers.
- **`latency_analytics.aggregate()`**: `gate_acceptance_rate` was hard-coded `1.0` ("Tier 1 only has accepted frames"); it is now processed / (processed + ingest-gate rejections + frame-gate rejections) over lifetime counters, and the aggregate exposes a cumulative `counters` dict (`received`, `processed`, `gate_rejections`, `frame_rejections`, `queue_drops`, `throttle_skips`, `tracking_drops`) so headless runs see every drop point without the viz rollup.
- `rtsm/cfg/rtsm.yaml`: the `diagnostics:` comment describes the trace (keys unchanged). `.gitignore` now ignores the benchmark harness's transient `rtsm.yaml.*bak*` backups so a killed run can never get its comment-stripped config committed.
- `run.py` / `demo.py` also close the shared writer in their `finally` (the pipeline closes it on normal shutdown; double close is a no-op).

Default off (`diagnostics.enabled: false`): every hook is a `None` check, no event objects are built, no file is created. Enable with `--set diagnostics.enabled=true` (optionally `--set diagnostics.event_log_path=...`).

## Behaviour neutrality (measured)

Headless `dual` replay of `recordings/session1` through `scripts/benchmark_datasheet.py`:

| run | objects/confirmed | frames | full multiset sha |
|---|---|---|---|
| trace OFF (default) | 121/66 | 53 | `92e0a8f1206d77da` = the headless anchor (`eval/baselines/2026-09-post-reconcile-headless/`) |
| trace ON (`--profile` with `diagnostics.enabled: true`) | 121/66 | 53 | `92e0a8f1206d77da` |

`gate_acceptance_rate` on that replay: **0.6023** (53 processed of 88 dequeued) — it read 1.0 before.

## The trace on session1 (trace-ON run)

- 240 `receiver` lines = 240 frames received: 152 `dropped/throttle` + 88 `enqueued`.
- 88 `dequeue` lines, and the enqueued `(frame_seq, t_sensor_ns)` sequence equals the dequeued sequence in order.
- Outcomes: `processed` 53 (`hard_max_s` 31, `parallax` 13, `keyframe` 9), `gate_rejected` 35 (`skip` 31, `near_recent_keyframe` 4) — matches `counters.gate_rejections` = 35; 0 frame-gate rejections.
- 53 `frame` lines = `latency.frame_count`; all carry `t_sensor_ns`.
- `queue_wait_s` at dequeue: median 0.0 s, max **1.5–1.75 s** across two runs — the queue wait the ingest lanes (P1 task 3) will bound.

The two replays were repeated after the review fixes with the same results (121/66 @53, `92e0a8f1206d77da`, trace OFF and ON).

## Tests

`tests/test_frame_flow_trace.py` (25, CPU-only): writer no-op when disabled / meta line + typed lines / concurrent writers keep lines intact; pipeline dequeue lines for gate rejection (reason + age), frame-gate rejection, accepted frame (written before segmentation), pose-less frame (`no_pose`, gate not consulted), disabled log changes nothing; pose-conversion failure is a `dropped` line; receiver lines for malformed-before-header, a non-object header, tracking_state, throttle (with frame_count), `parse_error` with header ids (and the exception still re-raised), decoded frames emit nothing at parse time, source label + queue-depth override, sink errors never break the receive path; a recorded three-frame replay through `ReplayReceiver` (lines tagged `replay`, real queue depth); ZeroMQ enqueue decisions and malformed pose messages; `gate_acceptance_rate` + `counters` from lifetime counts, zero when nothing dequeued, zero (not one) when everything was rejected.

## Reviewed

Three-lens adversarial review (behaviour neutrality + hot path; record completeness for the A/A gate; tests + wiring): not refuted on any lens. Its findings that are fixed here: the pose-conversion drop path left no dequeue line; parse-time exceptions left a line without ids and the replayer had no trace on that path; ZeroMQ malformed pose messages left no line; the replayer's parse-side lines read depth from a dummy queue and its enqueue lines paid an eager `qsize()` per frame even with tracing off; a non-object JSON header would have raised where it used to return None; string-literal reasons vs the constants; `age_s` was a queue wait, not an age; `FrameEvent.timestamp` was on a different clock. Deferred, noted in the plan: a receiver-local `rx_seq` echoed into `TimeBundle.seq` for ZeroMQ (P1 task 3 adds `IngestMeta`), a `session` marker line for multi-session files (P6), `lane` / `tracking_state` fields (P1 task 3).

## Not in this PR

Sensor-time clock, admit-before-decode, lanes, pose mailbox, headless Tier-2 rollup timer (P1 tasks 1–5; the cumulative `counters` half of task 5 is done here). The `rtsm eval` reader will consume this schema in P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
