### PR TITLE
pose: one receive-time writer, epoch-aware mailbox, no fail-open window (P1 task 4)

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -155,7 +155,13 @@ RTSM → {
   "robot_pose": {
     "xyz": [0.12, 0.05, 0.31],
     "quaternion_xyzw": [0.0, 0.0, 0.0, 1.0],
-    "timestamp": 1712345678.5
+    "timestamp": 1712345678.5,
+    "frame_epoch": 0,
+    "sensor_ts_ns": 683333172055083,
+    "pose_clock": "sender",
+    "age_s": 0.041,
+    "stale": false
+    /* diagnostic counters omitted -- see the REST API reference for the full payload */
   },
   "results": [
     {

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -188,7 +188,17 @@ curl "http://localhost:8002/search/semantic?query=coffee+mug&top_k=3&include_sna
   "robot_pose": {
     "xyz": [0.12, 0.05, 0.31],
     "quaternion_xyzw": [0.0, 0.0, 0.0, 1.0],
-    "timestamp": 1712345678.5
+    "timestamp": 1712345678.5,
+    "frame_epoch": 0,
+    "sensor_ts_ns": 683333172055083,
+    "pose_clock": "sender",
+    "age_s": 0.041,
+    "stale": false,
+    "stale_after_s": 0.5,
+    "writes_accepted": 812,
+    "sensor_ts_regressions": 0,
+    "rejected_writes": 0,
+    "rejected_by_reason": {"older_epoch": 0, "epochless_into_epoch": 0}
   },
   "results": [
     {
@@ -204,7 +214,7 @@ curl "http://localhost:8002/search/semantic?query=coffee+mug&top_k=3&include_sna
 }
 ```
 
-> **`robot_pose`**: All search responses include the robot's latest pose so agents can compute heading and distance to target objects in one atomic query. RTSM stores but does not compute pose — it's a passthrough from the sensor.
+> **`robot_pose`**: All search responses include the robot's latest pose so agents can compute heading and distance to target objects in one atomic query. RTSM stores but does not compute pose — it's a passthrough from the sensor, written **at receive time by the receiver** (websocket, replay, ZeroMQ) for every tracking-normal frame at input rate; the pipeline does not write it. The store is a latest-value mailbox keyed on `(frame_epoch, sensor_ts_ns)`: `frame_epoch` bumps when the sender starts a new streaming session (websocket: a new `session_id`; ZeroMQ: the tracking stamp jumping back by more than 5 s), and poses across a bump do not share a world frame. `sensor_ts_ns` is the sender's monotonic sensor stamp; `timestamp` is a wall clock for display, the sender's (`pose_clock: "sender"`) or this server's (`"server"`; `null` before any tag is known), and is not guaranteed monotone. `age_s` is the time since the last accepted write on the server's clock and `stale` is `age_s > robot_pose.stale_after_s` — **diagnostic only**: an agent must measure freshness on its own clock (the RC-car agent uses `stale_abort_s`) and treat a non-advancing `timestamp` as a frozen feed. `sensor_ts_regressions` counts accepted writes whose stamp went backwards within one epoch (a looped replay, a bag loop, a stepped sender clock — the pose follows the sender); `rejected_writes` counts writes from a previous epoch or from an epoch-less writer, which only a second writer can produce.
 
 **Agent workflow**: Query RTSM for candidates with snapshots, then pass crops to Gemini/GPT-4V for visual verification:
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -254,6 +254,26 @@ units:
 
 ---
 
+### Robot pose mailbox (diagnostic threshold)
+
+```yaml
+robot_pose:
+  stale_after_s: 0.5    # /stats.robot_pose.stale = age_s > this; diagnostic only; finite, > 0
+```
+
+`/stats.robot_pose` (also embedded in every search response) is a latest-value
+mailbox written at receive time by the receiver for every tracking-normal
+frame; the pipeline does not write it. `age_s` is measured on the server's own
+clock since the last accepted write, and `stale` flags `age_s > stale_after_s`.
+The flag is **diagnostic**: RTSM never acts on it, and an agent must keep its
+own freshness bound (the RC-car agent's `stale_abort_s`). The default 0.5 s is
+2.5 nominal periods of a 5 Hz phone stream (session1's receive gaps: p99
+0.27 s, max 0.35 s, so 0.3 would flicker on ordinary WiFi jitter) and flips within half a
+second of the stream stopping; under replay it is true by definition once the
+recording ends. A stamp that goes backwards within one session is accepted
+and counted (`sensor_ts_regressions`), never used to freeze the pose; a bad
+value for `stale_after_s` is a startup config error.
+
 ## Ingest Clock & Admission Timing
 
 Frame admission and memory timing (the receiver's non-keyframe throttle, the

--- a/docs/guides/rtabmap-setup.md
+++ b/docs/guides/rtabmap-setup.md
@@ -71,16 +71,24 @@ python rtabmap_zmq_bridge.py --rtabmap-addr localhost:5555 --zmq-pub tcp://127.0
 
 ### Message Format
 
-The bridge publishes pose messages:
+The bridge publishes pose messages as `[topic, json]` multipart frames; the
+subscriber (`rtsm/io/zeromq.py`) parses this shape:
 
 ```json
-{
-  "timestamp": 1705312200.123,
-  "position": [1.2, 0.4, 2.1],
-  "orientation": [0.0, 0.0, 0.0, 1.0],
-  "frame_id": 12345
-}
+{"stamp_ms": 1705312200123, "T_wc": [x, y, z, roll, pitch, yaw]}
 ```
+
+`rtabmap.tracking_pose` (~30 Hz) carries `stamp_ms`; `rtabmap.kf_pose` carries
+`kf_id` and should carry `stamp_ms` too. **Clock contract:** `stamp_ms` is
+milliseconds on the same clock as `camera.rgbd`'s `ts_ns` (unix on the
+reference bridge); frames are paired within 30 ms of the pose stamp. A
+`kf_pose` without a stamp inherits the last tracking stamp (counted in the
+subscriber's `kf_stamps_inherited`), so the keyframe is attached to the newest
+image rather than the node's own; if that image was already admitted as a
+non-keyframe and no newer frame exists yet, the keyframe re-processes it (one
+duplicate GPU pass per such keyframe). Add `stamp_ms` on the bridge to remove
+both the lag and the duplicate. A tracking stamp that jumps back by more than 5 s (bag loop, bridge
+restart) starts a new `frame_epoch` on the robot pose.
 
 ---
 

--- a/eval/baselines/2026-09-sensor-clock/README.md
+++ b/eval/baselines/2026-09-sensor-clock/README.md
@@ -69,3 +69,13 @@ session1 at 1×. `gate.out` is the script's verdict; the script itself is `p1t3_
 runs (`*.json`, `*.events.jsonl`, ~25k lines) are deliberately NOT committed: nothing compares against them (the references
 stay `B1.*` and `task2-admit-before-decode/S.*`), and the script regenerates them in ~7 min. From this record on, raw
 artifacts are gitignored under `eval/baselines/`; only a new reference anchor is force-added.
+
+## Task 4 reproduction (pose mailbox, 2026-09-10) — `task4-pose-mailbox/`
+
+Same harness, branch `feature/pose-mailbox` (main `1f22934` + the mailbox). **M** = packaged default (lossless, sensor
+clock): 124/65 @53 `ad6f71a5b89c8506` = this anchor; dequeue (86) and receiver (240) sequences identical to B1; per-line
+`(decision, reason, frame_seq, depth_valid_frac)` identical to `task2-admit-before-decode/S.events.jsonl`. Final
+`/stats.robot_pose` `xyz / quaternion_xyzw / timestamp / frame_epoch` equal the task-2 record (session1's last received
+frame, seq 405, epoch 0); `sensor_ts_ns` = that frame's stamp; `pose_clock: sender`; **one writer:** `writes_accepted`
+240 = every tracking-normal receiver line, `sensor_ts_regressions` 0, `rejected_writes` 0. **PASS.** Script + verdict only
+(raw artifacts gitignored).

--- a/eval/baselines/2026-09-sensor-clock/task4-pose-mailbox/gate.out
+++ b/eval/baselines/2026-09-sensor-clock/task4-pose-mailbox/gate.out
@@ -1,0 +1,9 @@
+== M rc=0 ==
+M: (124, 65) frames 53 sha ad6f71a5b89c8506 | meta policy=lossless clock=sensor | sources {'replay': 240}
+   vs B1: multiset IDENTICAL | dequeue identical (86) | receiver identical (240)
+   vs task-2 S per-line incl. depth_valid_frac: identical (240)
+   robot_pose core == task-2 S: True | (xyz/quat/timestamp/frame_epoch match)
+   new keys present: True | sensor_ts_ns == last received frame stamp: True (683373591451416 vs 683373591451416) | pose_clock sender | stale True age_s 45.156
+   single writer: writes_accepted 240 == tracking-normal receiver lines 240 | regressions 0 | rejected 0 {'older_epoch': 0, 'epochless_into_epoch': 0} -> OK
+HARD GATE: PASS
+P1T4_GATE_DONE

--- a/eval/baselines/2026-09-sensor-clock/task4-pose-mailbox/p1t4_gate.sh
+++ b/eval/baselines/2026-09-sensor-clock/task4-pose-mailbox/p1t4_gate.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# P1 task 4 gate: headless dual replay of session1 (default policy = lossless, clock = sensor).
+#   HARD: multiset == sensor anchor 124/65@53 ad6f71a5b89c8506; dequeue + receiver sequences identical to B1;
+#         per-line (decision, reason, frame_seq, depth_valid_frac) identical to task-2 S;
+#         final /stats.robot_pose xyz / quaternion_xyzw / timestamp / frame_epoch == task-2 S (last received frame, epoch 0);
+#         robot_pose payload carries the new keys (sensor_ts_ns == the last received frame's stamp, pose_clock=sender, age_s, stale);
+#         single writer: writes_accepted == tracking-normal receiver lines (240), sensor_ts_regressions == 0, rejected_writes == 0.
+set -u
+cd /c/Users/konam/Desktop/calabi-repo/rtsm || exit 1
+SP="C:/Users/konam/AppData/Local/Temp/claude/C--Users-konam-Desktop-calabi-repo-rtsm/c99f81f1-d743-4906-85ee-b894ab355ce0/scratchpad"
+OUT="$SP/p1t4_gate"; mkdir -p "$OUT"
+moved=0
+if [ -d model_store/faiss ] && [ ! -d model_store/faiss.pre-p1t4 ]; then mv model_store/faiss model_store/faiss.pre-p1t4; moved=1; fi
+run() {
+  local label="$1"; shift
+  printf 'diagnostics:\n  enabled: true\n  event_log_path: "%s/%s.events.jsonl"\n' "$OUT" "$label" > "$OUT/$label.profile.yaml"
+  rm -rf model_store/faiss reports/datasheet_raw_dual*.json
+  python -X utf8 scripts/benchmark_datasheet.py dual --profile "$OUT/$label.profile.yaml" "$@" > "$OUT/$label.harness.stdout" 2>&1; local rc=$?
+  local raw; raw=$(ls reports/datasheet_raw_dual.*.json 2>/dev/null | head -1)
+  cp -f "$raw" "$OUT/$label.json" 2>/dev/null; cp -f reports/run_dual.log "$OUT/$label.log" 2>/dev/null
+  ls rtsm/cfg/rtsm.yaml.*bak* 2>/dev/null && echo "WARN: stray harness backup present"
+  echo "== $label rc=$rc =="
+}
+run M
+rm -rf model_store/faiss
+if [ $moved = 1 ]; then mv model_store/faiss.pre-p1t4 model_store/faiss; fi
+python -X utf8 - "$OUT" <<'PY'
+import json,sys,hashlib
+from collections import Counter
+out=sys.argv[1]; ref='eval/baselines/2026-09-sensor-clock'
+def load(jp, ep):
+    d=json.load(open(jp,encoding='utf-8')); rows=[json.loads(l) for l in open(ep,encoding='utf-8') if l.strip()]
+    full=(d.get('objects_full') or {}).get('objects') or []
+    ms=Counter((o.get('label_primary'),tuple(round(float(v),3) for v in o.get('xyz_world') or []),int(o.get('hits') or 0),bool(o.get('confirmed'))) for o in full)
+    sha=hashlib.sha256(json.dumps(sorted(map(list,ms.elements())),default=str).encode()).hexdigest()[:16]
+    wm=d.get('working_memory') or {}; lat=d.get('latency') or {}
+    rx_rows=[r for r in rows if r['kind']=='receiver']
+    dq=[(r['frame_seq'],r['t_sensor_ns'],r['outcome'],r['reason']) for r in rows if r['kind']=='dequeue']
+    rx=[(r['decision'],r['reason'],r['frame_seq'],r.get('t_sensor_ns'),r.get('is_keyframe')) for r in rx_rows]
+    rxd=[(r['decision'],r['reason'],r['frame_seq'],None if r.get('depth_valid_frac') is None else round(r['depth_valid_frac'],6)) for r in rx_rows]
+    last_rx=[r for r in rx_rows if r['reason'] not in ('tracking_state','malformed')][-1]   # the sink fires for throttled frames too
+    n_parse_err=sum(1 for r in rx_rows if r['reason']=='parse_error')
+    return dict(sha=sha,objs=(wm.get('objects'),wm.get('confirmed')),frames=lat.get('frame_count'),dq=dq,rx=rx,rxd=rxd,
+                src=Counter(r.get('source') for r in rx_rows), meta=rows[0], pose=wm.get('robot_pose'), last_rx=last_rx, n_parse_err=n_parse_err)
+def same(x,y):
+    if x==y: return f'identical ({len(x)})'
+    i=next((i for i,(p,q) in enumerate(zip(x,y)) if p!=q), min(len(x),len(y)))
+    return f'DIFFER at {i}: {x[i] if i<len(x) else None} vs {y[i] if i<len(y) else None} (lens {len(x)} vs {len(y)})'
+B1=load(f'{ref}/B1.json',f'{ref}/B1.events.jsonl'); S2=load(f'{ref}/task2-admit-before-decode/S.json',f'{ref}/task2-admit-before-decode/S.events.jsonl')
+M=load(f'{out}/M.json',f'{out}/M.events.jsonl')
+print(f'M: {M["objs"]} frames {M["frames"]} sha {M["sha"]} | meta policy={M["meta"].get("ingest_policy")} clock={M["meta"].get("ingest_clock")} | sources {dict(M["src"])}')
+print('   vs B1: multiset', 'IDENTICAL' if M['sha']==B1['sha'] else 'DIFFER', '| dequeue', same(M['dq'],B1['dq']), '| receiver', same(M['rx'],B1['rx']))
+print('   vs task-2 S per-line incl. depth_valid_frac:', same(M['rxd'],S2['rxd']))
+p=M['pose'] or {}; sp=S2['pose'] or {}
+core=lambda d: {k:d.get(k) for k in ('xyz','quaternion_xyzw','timestamp','frame_epoch')}
+pose_ok = core(p)==core(sp)
+print('   robot_pose core == task-2 S:', pose_ok, '|', core(p) if not pose_ok else '(xyz/quat/timestamp/frame_epoch match)')
+keys_ok = all(k in p for k in ('sensor_ts_ns','pose_clock','age_s','stale','stale_after_s','rejected_writes','rejected_by_reason','writes_accepted','sensor_ts_regressions'))
+stamp_ok = p.get('sensor_ts_ns')==M['last_rx']['t_sensor_ns']
+print('   new keys present:', keys_ok, '| sensor_ts_ns == last received frame stamp:', stamp_ok, f'({p.get("sensor_ts_ns")} vs {M["last_rx"]["t_sensor_ns"]})', '| pose_clock', p.get('pose_clock'), '| stale', p.get('stale'), 'age_s', p.get('age_s'))
+n_normal = sum(1 for r in M['rx'] if r[1] not in ('tracking_state','malformed'))
+writer_ok = (M['n_parse_err']==0 and p.get('writes_accepted')==n_normal and p.get('sensor_ts_regressions')==0 and p.get('rejected_writes')==0)   # identity exact when no parse_error (sink fires at 5c, before the decodes)
+print('   single writer: writes_accepted', p.get('writes_accepted'), '== tracking-normal receiver lines', n_normal, '| regressions', p.get('sensor_ts_regressions'), '| rejected', p.get('rejected_writes'), p.get('rejected_by_reason'), '->', 'OK' if writer_ok else 'VIOLATED')
+ok = (M['sha']==B1['sha'] and M['dq']==B1['dq'] and M['rx']==B1['rx'] and M['rxd']==S2['rxd'] and dict(M['src'])=={'replay':240}
+      and pose_ok and keys_ok and stamp_ok and p.get('pose_clock')=='sender' and writer_ok)
+print('HARD GATE:', 'PASS' if ok else 'FAIL')
+PY
+echo P1T4_GATE_DONE

--- a/examples/rc_car_agent/tests/test_rtsm_client.py
+++ b/examples/rc_car_agent/tests/test_rtsm_client.py
@@ -101,3 +101,18 @@ def test_semantic_query_assembles_snapshot(mock_rtsm):
     assert (top.id, top.confirmed) == ("obj_7", True)
     assert top.xyz_world == [0.5, 0.8, 1.5]
     assert res.results[1].xyz_world is None      # unconfirmed hit without xyz
+
+
+
+def test_pose_parse_ignores_mailbox_diagnostics():
+    """RTSM's robot_pose carries mailbox diagnostics since P1 task 4 (age_s,
+    stale, pose_clock, counters). The client reads only the geometry, the
+    timestamp and the epoch; the extra keys must not change the sample."""
+    from rtsm_client import RtsmClient
+    c = RtsmClient("http://127.0.0.1:1", timeout_s=0.1)
+    plain = {"xyz": [1.0, 2.0, 3.0], "quaternion_xyzw": [0, 0, 0, 1], "timestamp": 1751000000.5, "frame_epoch": 3}
+    rich = dict(plain, sensor_ts_ns=683333172055083, pose_clock="sender", age_s=0.04, stale=False,
+                stale_after_s=0.5, writes_accepted=10, sensor_ts_regressions=0, rejected_writes=0,
+                rejected_by_reason={"older_epoch": 0, "epochless_into_epoch": 0})
+    a, b = c._parse_pose(plain), c._parse_pose(rich)
+    assert (a.xyz, a.quaternion_xyzw, a.timestamp, a.frame_epoch) == (b.xyz, b.quaternion_xyzw, b.timestamp, b.frame_epoch)

--- a/examples/rc_car_agent/tests/test_server.py
+++ b/examples/rc_car_agent/tests/test_server.py
@@ -21,7 +21,12 @@ from server import BENCH_DUMMY_GOAL, create_app
 from test_esp32_bridge import _RecordingHandler
 
 POSE = {"xyz": [0.0, 0.3, 0.0], "quaternion_xyzw": [0, 0, 0, 1],
-        "timestamp": 1751000000.0, "frame_epoch": 7}
+        "timestamp": 1751000000.0, "frame_epoch": 7,
+        # RTSM's pose mailbox diagnostics (P1 task 4) -- present in every real
+        # payload, ignored by the agent on purpose (it keeps its own clock).
+        "sensor_ts_ns": 683333172055083, "pose_clock": "sender", "age_s": 9.9, "stale": True,
+        "stale_after_s": 0.5, "writes_accepted": 812, "sensor_ts_regressions": 0,
+        "rejected_writes": 0, "rejected_by_reason": {"older_epoch": 0, "epochless_into_epoch": 0}}
 CLEARANCE = {"clearance_m": 3.0, "valid_frac": 0.9, "timestamp": 1751000000.0}
 GOOD_STATS = {"objects": 12, "confirmed": 8, "robot_pose": POSE,
               "forward_clearance": CLEARANCE}
@@ -422,6 +427,53 @@ def test_frame_epoch_abort_e2e(env_car):
         car.epoch = car.epoch + 1                     # new sender session
         assert _wait(lambda: _result(c) == "frame_reset", timeout=5.0)
         assert any(rec["path"] == "/stop" for rec in esp_srv.recorded)
+
+
+def test_diagnostic_stale_flag_is_ignored_e2e(env_car, monkeypatch):
+    """Contract with RTSM's robot_pose mailbox (P1 task 4): /stats.robot_pose
+    now carries `stale` / `age_s` (diagnostic, RTSM never acts on them). The
+    agent measures freshness on ITS OWN clock via an advancing timestamp;
+    a payload saying stale=true with a live, advancing pose must not stop
+    the mission. The safety bound stays stale_abort_s."""
+    cfg, rtsm, bridge, rtsm_srv, esp_srv, car, tmp_path = env_car
+    from fake_car import FakeCar
+    real = FakeCar.pose_payload
+
+    def with_diagnostics(self):
+        p = real(self)
+        p.update({"stale": True, "age_s": 9.9, "stale_after_s": 0.5, "pose_clock": "sender",
+                  "sensor_ts_ns": int(p["timestamp"] * 1e9), "sensor_ts_regressions": 3, "rejected_writes": 0,
+                  "rejected_by_reason": {"older_epoch": 0, "epochless_into_epoch": 0}, "writes_accepted": 400})
+        return p
+    monkeypatch.setattr(FakeCar, "pose_payload", with_diagnostics)
+    target = rtsm_srv.semantic_results[0]["xyz_world"]
+    with TestClient(create_app(cfg, rtsm, bridge)) as c:
+        c.post("/command", json={"goal": "go to the red mug"})
+        assert _wait(lambda: _result(c) == "arrived", timeout=15.0)
+        assert car.ground_dist_to(target) <= cfg.nav.arrival_threshold_m + 0.2
+
+
+def test_server_fresh_flag_does_not_override_own_clock_e2e(env_car, monkeypatch):
+    """Negative pin of the same contract: a payload claiming stale=false /
+    age_s=0 while the timestamp has STOPPED advancing must still stale_stop
+    within the agent's own stale_abort_s."""
+    cfg, rtsm, bridge, rtsm_srv, esp_srv, car, tmp_path = env_car
+    from fake_car import FakeCar
+    real = FakeCar.pose_payload
+
+    def claims_fresh(self):
+        p = real(self)
+        p.update({"stale": False, "age_s": 0.0, "stale_after_s": 0.5, "pose_clock": "sender"})
+        return p
+    monkeypatch.setattr(FakeCar, "pose_payload", claims_fresh)
+    rtsm_srv.semantic_results[0]["xyz_world"] = [0.0, 0.3, 8.0]   # far target
+    with TestClient(create_app(cfg, rtsm, bridge)) as c:
+        c.post("/command", json={"goal": "go to the red mug"})
+        assert _wait(lambda: (c.get("/status").json().get("task") or {}).get("ticks", 0) > 3)
+        frozen_at = time.monotonic()
+        car.freeze()
+        assert _wait(lambda: _result(c) == "stale_stop", timeout=cfg.nav.stale_abort_s + 3.0)
+        assert time.monotonic() - frozen_at < cfg.nav.stale_abort_s + 2.0
 
 
 def test_stale_abort_bounded_e2e(env_car):

--- a/rtsm/cfg/rtsm.yaml
+++ b/rtsm/cfg/rtsm.yaml
@@ -137,6 +137,18 @@ ingest:
   max_frame_age_s: 2.0            # latest: non-keyframe older than this at dequeue is discarded (null disables)
   lossless_depth: 32              # lossless: FIFO depth before the producer waits (~8.5 MB per decoded frame)
 
+# -------------------- Robot pose (mailbox) --------------------
+robot_pose:
+  # DIAGNOSTIC ONLY. /stats.robot_pose.stale = age_s > stale_after_s, where
+  # age_s is the time since the last ACCEPTED pose write on this process's
+  # clock (never wall-now minus a sender stamp). The RC-car agent's
+  # stale_abort_s (2.5 s) is the safety bound and lives in the agent; RTSM
+  # never acts on this flag. 0.5 = 2.5 nominal periods of a 5 Hz phone
+  # stream (session1 receive gaps: p99 0.27 s, max 0.35 s; 0.3 would flicker);
+  # flips within half a second of the stream stopping. Under replay it is
+  # true by definition once the recording ends. Finite, > 0.
+  stale_after_s: 0.5
+
 units:
   # Convert incoming values to meters at ingestion
   # If your dataset publishes millimeters, set to 0.001

--- a/rtsm/core/pipeline.py
+++ b/rtsm/core/pipeline.py
@@ -565,11 +565,14 @@ class Pipeline:
                     look_cell=None,
                     now_mono=self.clock.now_mono(),
                 )
-                # Store latest robot pose for API queries
-                timestamp = float(pkt.time.t_wall_utc_s or pkt.time.t_mono_s or 0.0)
-                self.working_mem.update_robot_pose(twc, q, timestamp)
+                # The robot pose is NOT written here any more (P1 task 4): every
+                # receiver writes it at receive time (websocket / replay /
+                # zeromq pose_sink -> WorkingMemory.update_robot_pose), which
+                # is fresher than any dequeue-time write and leaves the
+                # mailbox with exactly one writer. A pipeline write here was
+                # the only thing the old 2 s guard ever had to arbitrate.
         except Exception:
-            logger.warning("Post-processing ingest bookkeeping or robot-pose update failed", exc_info=True)
+            logger.warning("Post-processing ingest bookkeeping failed", exc_info=True)
 
         # ---- Phase 0 diagnostic event log (no-op when disabled) ----
         if self._event_log.enabled:

--- a/rtsm/demo.py
+++ b/rtsm/demo.py
@@ -123,6 +123,11 @@ def run_demo(argv: list[str] | None = None) -> None:
     # recording, so `auto` resolves to sensor: memory timing follows the frames'
     # own timestamps and the result does not depend on replay pacing.
     from rtsm.core.clock import make_clock, resolve_clock_mode
+    # These two are used by the validation block right below; importing them
+    # further down the function made them unbound locals here (UnboundLocalError
+    # at startup -- `rtsm demo` was broken on main between PR #33 and this fix).
+    from rtsm.io.ingest_lanes import LaneConfig, lane_drop_handler, make_ingest_queue
+    from rtsm.stores.working_memory import WorkingMemory, resolve_pose_stale_after_s
     try:
         clock_mode = resolve_clock_mode((cfg.get("ingest") or {}).get("clock", "auto"), replay=True)
     except ValueError as exc:
@@ -133,6 +138,7 @@ def run_demo(argv: list[str] | None = None) -> None:
     # replays, so `auto` resolves to lossless (producer-paced FIFO, no drops).
     try:
         lane_cfg = LaneConfig.from_cfg(cfg, replay=True)
+        resolve_pose_stale_after_s(cfg)     # robot_pose.stale_after_s: finite, > 0
     except ValueError as exc:
         parser.error(str(exc))
     logger.info("Ingest policy: %s (ingest.policy=%s)", lane_cfg.policy, lane_cfg.configured_policy)
@@ -160,12 +166,10 @@ def run_demo(argv: list[str] | None = None) -> None:
 
     # ── Initialize spatial memory ──
     print("  [5/5] Initializing spatial memory + pipeline...")
-    from rtsm.stores.working_memory import WorkingMemory
     from rtsm.stores.proximity_index import ProximityIndex, GridSpec
     from rtsm.core.association import Associator
     from rtsm.core.ingest_gate import IngestGate
     from rtsm.stores.sweep_cache import SweepCache
-    from rtsm.io.ingest_lanes import LaneConfig, lane_drop_handler, make_ingest_queue
     from rtsm.io.replayer import ReplayReceiver
     from rtsm.api.server import create_app, start_server, ResetComponents
     from rtsm.utils.net import get_local_ipv4_addresses

--- a/rtsm/io/websocket.py
+++ b/rtsm/io/websocket.py
@@ -298,11 +298,13 @@ class WebSocketReceiver:
         self._on_pose_corrections_batch = on_pose_corrections_batch
         self._on_raw_message = on_raw_message
         self._on_handshake_done = on_handshake_done
-        # Called as pose_sink(t_wc, q_wc_xyzw, unix_ts, frame_epoch) for
-        # EVERY frame with normal tracking — including frames the
+        # Called as pose_sink(t_wc, q_wc_xyzw, unix_ts, frame_epoch,
+        # sensor_ts_ns=<header timestamp_ns>, pose_clock="sender"|"server")
+        # for EVERY frame with normal tracking — including frames the
         # keyframe/interval throttle skips — so consumers (e.g.
         # WorkingMemory.update_robot_pose) see pose at the full input rate,
-        # not the pipeline processing rate.
+        # not the pipeline processing rate. The mailbox orders writes on
+        # (frame_epoch, sensor_ts_ns); pose_clock says where unix_ts came from.
         self._pose_sink = pose_sink
         # Called as clearance_sink(clearance_m, valid_frac, wall_ts) for
         # every frame that passes the tracking filter and the non-KF
@@ -794,17 +796,20 @@ class WebSocketReceiver:
             q_xyzw = rotmat_to_quat_xyzw(T_wc_mat[:3, :3].astype(np.float32))
 
         # Treat a missing/zero unix_timestamp as absent and substitute server
-        # wall time; the same value flows into TimeBundle.t_wall_utc_s, so the
-        # pose sink and the pipeline's later update_robot_pose call always
-        # share one clock (the guard compares timestamps across the two).
+        # wall time; the same value flows into TimeBundle.t_wall_utc_s. The
+        # mailbox ORDERS writes on the header's sensor stamp (timestamp_ns),
+        # not on this wall value; pose_clock records which clock it is.
         unix_ts = float(header.get("unix_timestamp") or time.time())
+        pose_clock = "sender" if header.get("unix_timestamp") else "server"
 
         # 5c. Pose sink: latest-pose passthrough for every tracking-normal
         # frame, even ones the throttle below skips. Same (post-flip) pose the
         # FramePacket carries, so consumers see one consistent convention.
         if self._pose_sink is not None:
             try:
-                self._pose_sink(t_wc, q_xyzw, unix_ts, self._frame_epoch)
+                self._pose_sink(t_wc, q_xyzw, unix_ts, self._frame_epoch,
+                                sensor_ts_ns=(int(hdr_ts) if hdr_ts else None),   # 0 / missing = no stamp
+                                pose_clock=pose_clock)
             except Exception as e:
                 logger.error(f"[websocket] pose_sink callback error: {e}")
 

--- a/rtsm/io/zeromq.py
+++ b/rtsm/io/zeromq.py
@@ -55,6 +55,14 @@ class ZeroMQSubscriber:
         latency_analytics: Optional[Any] = None,
         event_sink: Optional[Callable[[Any], None]] = None,
         throttle_clock: str = "wall",
+        # Receive-time robot-pose passthrough (WorkingMemory.update_robot_pose):
+        # called for EVERY parsed tracking_pose at input rate (NOT for
+        # kf_pose: a keyframe carries the node's pose, 50-300 ms behind the
+        # tracking stream), as pose_sink(t_wc, q_xyzw, time.time(),
+        # frame_epoch, sensor_ts_ns=stamp, pose_clock="server"). The epoch is
+        # receiver-minted: 0, +1 whenever the tracking stamp goes backwards by
+        # more than POSE_EPOCH_REBASE_S (a bag loop, a bridge restart).
+        pose_sink: Optional[Callable[..., Any]] = None,
         # FrameWindow now holds ENCODED frames (JPEG / PNG bytes, ~0.35 MB per
         # 640x480 frame). Its old defaults (30 s, 2000 items) held ~1.9 GB of
         # decoded frames. The window must cover the LATENCY OF A kf_pose
@@ -151,6 +159,14 @@ class ZeroMQSubscriber:
         self._last_nonkf_admit_sensor_ns: Optional[int] = None
         # Frame-flow trace sink (ReceiverEvent per decision); None = off.
         self._event_sink = event_sink
+        self._pose_sink = pose_sink
+        self._kf_stamps_inherited: int = 0   # kf_pose messages that arrived without a stamp (counted in _handle_kf_pose)
+        self._last_enq_cam_ts: Optional[int] = None   # camera stamp the last admitted frame was paired with
+        # Receiver-minted session epoch (ZeroMQ has no hello/session_id): a
+        # tracking stamp that jumps back by more than POSE_EPOCH_REBASE_S is a
+        # restarted source -> new epoch on the pose mailbox, on every
+        # FramePacket (SensorClock re-bases on it) and in liveness().
+        self._frame_epoch: int = 0
         self._nonkf_min_interval_s: float = 0.5  # Max ~2 non-KF per second
 
         # Frame-flow liveness stamps (read by the watchdog). The subscriber
@@ -228,22 +244,57 @@ class ZeroMQSubscriber:
             logger.error(f"[zeromq] camera.rgbd: parse error: {e}")
 
     def _parse_rtabmap_pose(self, json_data: dict) -> tuple[int, np.ndarray, np.ndarray]:
+        """Parse an RTABMap pose (see _parse_rtabmap_pose_ex); 3-tuple form."""
+        ts_ns, t_wc, q_xyzw, _stamped = self._parse_rtabmap_pose_ex(json_data)
+        return ts_ns, t_wc, q_xyzw
+
+    def _parse_rtabmap_pose_ex(self, json_data: dict) -> tuple[int, np.ndarray, np.ndarray, bool]:
         """
         Parse RTABMap pose from JSON.
 
         RTABMap format: T_wc = [x, y, z, roll, pitch, yaw] (Euler angles in radians)
 
         Returns:
-            Tuple of (ts_ns, t_wc, q_xyzw)
+            Tuple of (ts_ns, t_wc, q_xyzw, stamped). ``stamped`` is False when
+            the message carried no stamp and ts_ns was INHERITED.
         """
-        # Get timestamp - RTABMap uses stamp_ms for tracking_pose, kf_id for kf_pose
+        # Timestamp: tracking_pose carries stamp_ms; kf_pose carries kf_id only
+        # (bridge-side gap). A stamp-less message inherits the last tracking
+        # stamp (the keyframe IS the latest tracked pose), else the newest
+        # camera frame in the window, and only as a last resort this
+        # process's clock -- which used to be the FIRST resort and paired the
+        # keyframe with whatever frame was newest while breaking the sensor
+        # ordering the pose mailbox relies on.
+        stamped = True
         if "stamp_ms" in json_data:
             ts_ns = int(json_data["stamp_ms"] * 1_000_000)  # ms to ns
         elif "ts_ns" in json_data:
             ts_ns = int(json_data["ts_ns"])
         else:
-            # Use current time as fallback
-            ts_ns = int(time.time_ns())
+            stamped = False
+            wm = int(getattr(self.fw, "watermark", 0) or 0)
+            if self._last_pose_ts_ns is not None:
+                ts_ns = int(self._last_pose_ts_ns)
+                # That tracking pose may already have enqueued THIS image (it
+                # passed the throttle): if a NEWER camera frame exists, pair
+                # the keyframe with it so one image is not processed twice.
+                # (Pairing is by nearest camera stamp, so compare on the
+                # camera stamp the tracking pose actually used.) If the
+                # enqueued image is still the newest, the keyframe re-processes
+                # it -- one duplicate GPU pass per stamp-less keyframe that
+                # follows a throttle-admitted tracking pose; the bridge-side
+                # stamp_ms on kf_pose removes it.
+                match = getattr(self.fw, "match_stamp", None)
+                cam = match(ts_ns) if match is not None else None
+                if cam is not None and cam == self._last_enq_cam_ts and wm > cam:
+                    ts_ns = wm
+            elif wm:
+                ts_ns = wm
+            else:
+                # Nothing on the sensor clock is known yet; this value cannot
+                # pair with any frame (the window is empty) and never reaches
+                # the pose mailbox (kf_pose does not write the pose).
+                ts_ns = int(time.time_ns())
 
         # Parse pose [x, y, z, roll, pitch, yaw]
         T_wc = json_data["T_wc"]
@@ -264,7 +315,7 @@ class ZeroMQSubscriber:
         # Convert Euler to quaternion
         q_xyzw = euler_to_quat_xyzw(roll, pitch, yaw)
 
-        return ts_ns, t_wc, q_xyzw
+        return ts_ns, t_wc, q_xyzw, stamped
 
     def _handle_tracking_pose(self, parts: List[bytes]) -> None:
         """
@@ -281,12 +332,28 @@ class ZeroMQSubscriber:
 
         try:
             json_data = json.loads(parts[1].decode("utf-8"))
-            ts_ns, t_wc, q_xyzw = self._parse_rtabmap_pose(json_data)
+            ts_ns, t_wc, q_xyzw, _stamped = self._parse_rtabmap_pose_ex(json_data)
+
+            # Restarted source? (bag loop, bridge restart): stamp went back by
+            # more than POSE_EPOCH_REBASE_S -> new receiver-minted epoch. A
+            # non-positive stamp is "no stamp" (as for SensorClock and the
+            # mailbox) and neither bumps the epoch nor becomes the reference.
+            last = self._last_pose_ts_ns
+            if ts_ns > 0:
+                if last is not None and ts_ns < int(last) - int(self.POSE_EPOCH_REBASE_S * 1e9):
+                    self._frame_epoch += 1
+                    logger.warning(
+                        "[zeromq] tracking stamp jumped back %.1f s (%d -> %d): new frame_epoch %d",
+                        (int(last) - ts_ns) / 1e9, int(last), ts_ns, self._frame_epoch,
+                    )
+                self._last_pose_ts_ns = ts_ns
 
             # Store latest pose
-            self._last_pose_ts_ns = ts_ns
             self._last_pose_t_wc = t_wc
             self._last_pose_q_xyzw = q_xyzw
+
+            # Receive-time robot pose (input rate, independent of admission)
+            self._emit_pose(t_wc, q_xyzw, ts_ns)
 
             # Try to assemble non-keyframe
             self._try_enqueue_frame(ts_ns, t_wc, q_xyzw, is_keyframe=False)
@@ -311,14 +378,22 @@ class ZeroMQSubscriber:
 
         try:
             json_data = json.loads(parts[1].decode("utf-8"))
-            ts_ns, t_wc, q_xyzw = self._parse_rtabmap_pose(json_data)
+            ts_ns, t_wc, q_xyzw, stamped = self._parse_rtabmap_pose_ex(json_data)
 
             # kf_id for logging/debugging
             kf_id = json_data.get("kf_id", -1)
+            if not stamped:
+                self._kf_stamps_inherited += 1
+
+            # No pose-mailbox write for keyframes: the node pose lags the
+            # tracking stream (50-300 ms, > 1 s in loop closure) and with an
+            # inherited stamp it would REPLACE the fresher tracking pose at
+            # the same key -- a periodic backwards blip an agent could read
+            # as a discontinuity. tracking_pose already writes at input rate.
 
             # Enqueue as keyframe
             self._try_enqueue_frame(ts_ns, t_wc, q_xyzw, is_keyframe=True)
-            logger.debug(f"[zmq] kf_pose: kf_id={kf_id}")
+            logger.debug(f"[zmq] kf_pose: kf_id={kf_id}{'' if stamped else ' (stamp inherited)'}")
 
         except Exception as e:
             logger.error(f"[zeromq] kf_pose: parse error: {e}")
@@ -579,6 +654,7 @@ class ZeroMQSubscriber:
             pose=pose,
             intr=intr,
             is_keyframe=is_keyframe,
+            frame_epoch=self._frame_epoch,
             ingest=IngestMeta(keyframe_origin=kf_origin, rx_seq=rx_seq),
         )
 
@@ -589,6 +665,7 @@ class ZeroMQSubscriber:
         if ok:
             self.last_enqueue_mono = time.monotonic()
             self._last_enq_ts_ns = ts_ns
+            self._last_enq_cam_ts = cam_ts
             frame_type = "KF" if is_keyframe else "frame"
             logger.debug(f"[zmq] enqueued {frame_type} -> queue={self.ingest_q.qsize()}")
             self._trace_rx(RX_ENQUEUED, "", ts_ns, is_keyframe, rx_seq=rx_seq,
@@ -600,6 +677,25 @@ class ZeroMQSubscriber:
             frame_type = "keyframe" if is_keyframe else "non-KF"
             logger.warning(f"[zeromq] ingest queue refused {frame_type} ({reason}); dropping")
             self._trace_rx(RX_DROPPED, reason, ts_ns, is_keyframe, rx_seq=rx_seq)
+
+    # A tracking stamp that goes back by more than this within the stream is a
+    # restarted source (bag loop, bridge restart) -> new receiver-minted epoch.
+    # Same constant as SensorClock.rebase_after_s so the clock and the mailbox
+    # agree on what a restart is.
+    POSE_EPOCH_REBASE_S = 5.0
+
+    def _emit_pose(self, t_wc: np.ndarray, q_xyzw: np.ndarray, ts_ns: int) -> None:
+        """Receive-time pose write (tracking poses only). `timestamp` is this
+        process's wall clock (RTAB-Map's stamp clock is not known to be unix),
+        tagged pose_clock="server"; the mailbox key is (receiver-minted epoch,
+        stamp). Never raises into the receive path."""
+        if self._pose_sink is None:
+            return
+        try:
+            self._pose_sink(t_wc, q_xyzw, time.time(), self._frame_epoch,
+                            sensor_ts_ns=int(ts_ns), pose_clock="server")
+        except Exception as e:
+            logger.error(f"[zeromq] pose_sink callback error: {e}")
 
     def _decode_rgbd(self, ts_ns: int, rgb_raw: Any, depth_raw: Any):
         """Decode a paired camera frame after admission; memoised per CAMERA
@@ -695,6 +791,8 @@ class ZeroMQSubscriber:
             "last_rx_mono": self.last_rx_mono,
             "last_enqueue_mono": self.last_enqueue_mono,
             "tracking_drops": 0,  # no tracking-state concept on the ZMQ path
+            "frame_epoch": self._frame_epoch,
+            "kf_stamps_inherited": self._kf_stamps_inherited,   # bridge-side gap: kf_pose without stamp_ms
         }
 
     def run_forever(self) -> None:

--- a/rtsm/run.py
+++ b/rtsm/run.py
@@ -19,7 +19,7 @@ except ImportError as e:
 
 # ── Core imports (always available) ──
 from rtsm.models.segmentation import get_segmenter
-from rtsm.stores.working_memory import WorkingMemory
+from rtsm.stores.working_memory import WorkingMemory, resolve_pose_stale_after_s
 from rtsm.stores.proximity_index import ProximityIndex, GridSpec
 from rtsm.core.association import Associator
 from rtsm.core.ingest_gate import IngestGate
@@ -122,6 +122,7 @@ def main():
     # for live receivers (its producer-paced put would block the receive loop).
     try:
         lane_cfg = LaneConfig.from_cfg(cfg, replay=bool(args.replay))
+        resolve_pose_stale_after_s(cfg)     # robot_pose.stale_after_s: finite, > 0
     except ValueError as exc:
         parser.error(str(exc))
     logger.info("Ingest policy: %s (ingest.policy=%s)", lane_cfg.policy, lane_cfg.configured_policy)
@@ -375,6 +376,9 @@ def main():
             pose_m_per_unit=float(units_cfg.get("pose_m_per_unit", 1.0)),
             on_kf_packet=vis_server.handle_kf_packet if vis_server else None,
             on_kf_pose_update=vis_server.handle_kf_pose_update if vis_server else None,
+            # Receive-time robot pose at input rate (pose mailbox); the
+            # dequeue-time write alone left /stats.robot_pose at ~1 Hz on ZMQ.
+            pose_sink=wm.update_robot_pose,
             event_sink=event_sink,
             throttle_clock=clock_mode,
             latency_analytics=latency_analytics,

--- a/rtsm/stores/working_memory.py
+++ b/rtsm/stores/working_memory.py
@@ -20,6 +20,32 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
+POSE_STALE_AFTER_S_DEFAULT = 0.5
+
+
+def resolve_pose_stale_after_s(cfg: Any) -> float:
+    """``robot_pose.stale_after_s`` -> float seconds (finite, > 0; default
+    0.5 = 2.5 nominal periods at a 5 Hz phone stream, so the DIAGNOSTIC flag
+    does not flicker on ordinary WiFi jitter yet flips within half a second of
+    the stream stopping). Raises ValueError so the runners can fail through
+    parser.error before any model loads."""
+    rp = (cfg.get("robot_pose") or {}) if isinstance(cfg, dict) else {}
+    if not isinstance(rp, dict):
+        raise ValueError(f"robot_pose must be a mapping of settings (robot_pose: {{stale_after_s: 0.5}}); got {rp!r}")
+    raw = rp.get("stale_after_s", POSE_STALE_AFTER_S_DEFAULT)
+    if raw is None:
+        return POSE_STALE_AFTER_S_DEFAULT
+    if isinstance(raw, bool):
+        raise ValueError(f"robot_pose.stale_after_s must be a number of seconds > 0; got {raw!r}")
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"robot_pose.stale_after_s must be a number of seconds > 0; got {raw!r}")
+    if not (v > 0) or v != v or v == float("inf"):
+        raise ValueError(f"robot_pose.stale_after_s must be a finite number > 0; got {raw!r}")
+    return v
+
 # --- type aliases ---
 Vec3 = np.ndarray  # shape (3,), float32
 Emb = np.ndarray   # shape (D,), float32 L2-normalized unless stated
@@ -173,11 +199,25 @@ class WorkingMemory:
 
         self._map: Dict[str, ObjectState] = {}
         self._lock = threading.RLock()
-        # Latest robot pose — passthrough from sensor (receive-time in live
-        # websocket mode; per processed frame on ZMQ/replay paths).
+        # Latest robot pose: a MAILBOX (Gate 4.5 plan, P1 task 4). Passthrough
+        # from the sensor, written at receive time by the ONE receiver in this
+        # process (websocket / replay / zeromq); the pipeline does not write
+        # it. (frame_epoch, sensor_ts_ns) is a regression detector, not a
+        # gate -- see update_robot_pose.
         self._latest_pose: Optional[Dict[str, Any]] = None
-        # Process-monotonic arrival time of the stored pose (guard window).
+        # Process-monotonic arrival time of the stored pose (-> age_s).
         self._latest_pose_arrival_mono: float = 0.0
+        self._pose_writes_accepted: int = 0
+        self._pose_rejects: Dict[str, int] = {self.POSE_REJECT_OLDER_EPOCH: 0, self.POSE_REJECT_EPOCHLESS: 0}
+        self._pose_consecutive_rejects: int = 0
+        self._pose_regressions: int = 0             # accepted writes whose stamp went backwards in-epoch
+        self._pose_last_regression_warn_mono: float = float("-inf")
+        # robot_pose.stale_after_s: DIAGNOSTIC threshold for the payload's
+        # `stale` flag (age_s above it). The RC-car agent's stale_abort_s is
+        # the safety bound and lives in the agent; RTSM never acts on this.
+        # Validated (finite, > 0); the runners call the same resolver before
+        # any model loads so a typo fails through parser.error.
+        self._pose_stale_after_s: float = resolve_pose_stale_after_s(cfg)
         # Latest forward-clearance summary from the depth stream (meters of
         # open space ahead of the camera). Written by the websocket receiver's
         # clearance_sink at receive time (rtsm/io/websocket.py step 8b), and
@@ -828,11 +868,12 @@ class WorkingMemory:
 
     # ---------- utilities ----------
 
-    # How long (by this process's monotonic clock) a stored pose out-ranks
-    # older-timestamped updates. Long enough to block the slow pipeline
-    # write (~0.5-1 s behind), short enough that a sender clock stepping
-    # backward (new device, NTP) recovers instead of freezing the pose.
-    _POSE_GUARD_WINDOW_S = 2.0
+    # Robot-pose mailbox rejection reasons (keys of robot_pose.rejected_by_reason).
+    # Both can only come from a SECOND writer: every shipped receiver writes at
+    # receive time with its own epoch, and the pipeline no longer writes at all.
+    POSE_REJECT_OLDER_EPOCH = "older_epoch"           # a frame from a previous streaming session
+    POSE_REJECT_EPOCHLESS = "epochless_into_epoch"    # writer knows no epoch, stored pose has one
+    _POSE_REGRESSION_WARN_EVERY_S = 60.0
 
     def update_robot_pose(
         self,
@@ -840,53 +881,130 @@ class WorkingMemory:
         q_wc_xyzw: np.ndarray,
         timestamp: float,
         frame_epoch: Optional[int] = None,
-    ) -> None:
-        """Store latest robot pose (passthrough from sensor).
+        *,
+        sensor_ts_ns: Optional[int] = None,
+        pose_clock: Optional[str] = None,
+    ) -> bool:
+        """Latest-value MAILBOX for the robot pose (passthrough from the sensor;
+        RTSM never computes or filters pose). Returns True when accepted.
 
-        RTSM does NOT compute or filter pose — it stores what the sensor provides.
-        This allows agents to query robot position + object positions atomically.
+        ONE writer per process: the receiver, at receive time, for every
+        tracking-normal frame (websocket / replay / zeromq). The pipeline does
+        not write the pose (P1 task 4 removed its dequeue-time write, which
+        was the only reason a compare-and-set ever had to arbitrate).
 
-        May be called from two writers: the receiver at frame-receive time
-        (fresh, input-rate) and the pipeline after processing (older frames).
-        Guarded compare-and-set under the WM lock: an update carrying a
-        strictly older timestamp is ignored while the stored pose is fresh
-        (received less than _POSE_GUARD_WINDOW_S ago), so a slow pipeline
-        write cannot overwrite a fresher receive-time pose — but a sender
-        clock discontinuity self-heals within the window rather than
-        rejecting all future updates. Timestamps must come from the same
-        clock per session (FramePacket wall time).
+        The key ``(frame_epoch, sensor_ts_ns)`` is therefore a REGRESSION
+        DETECTOR, not a gate: a same-epoch write whose stamp went backwards is
+        ACCEPTED (the sender says this is the pose now -- a looped replay, a
+        bag loop, a restarted bridge, a stepped clock) and counted in
+        ``sensor_ts_regressions`` with a WARNING at most once a minute.
+        ``timestamp`` (the wall value shown to agents) is the fallback key
+        when a side has no sensor stamp; a stamp <= 0 counts as none.
 
-        frame_epoch: opaque counter from the receiver that bumps when the
-        sender starts a new streaming session (world origin may have moved
-        — poses across a bump must not be assumed to share a world frame).
-        None means "this writer doesn't know the epoch" (pipeline writer,
-        ZMQ/replay) and PRESERVES the stored value rather than clearing it.
+        Two writes ARE rejected, both impossible from the single shipped
+        writer and kept as a safety net for embedders that add one:
+          writer epoch < stored epoch            -> older_epoch
+          writer epoch None, stored epoch known  -> epochless_into_epoch
+        A writer epoch above the stored one (new streaming session) and a
+        first epoch-bearing write into an epoch-less mailbox are accepted.
+
+        ``pose_clock`` tags where ``timestamp`` came from: ``sender`` (the
+        sender's own wall clock) or ``server`` (this process's time.time());
+        None keeps the stored tag.
         """
         ts = float(timestamp)
+        s_ns = int(sensor_ts_ns) if (sensor_ts_ns is not None and int(sensor_ts_ns) > 0) else None
+        epoch = int(frame_epoch) if frame_epoch is not None else None    # numpy ints -> JSON-safe ints
         now_mono = time.monotonic()
         with self._lock:
             lp = self._latest_pose
-            if (
-                lp is not None
-                and ts < lp["timestamp"]
-                and (now_mono - self._latest_pose_arrival_mono) < self._POSE_GUARD_WINDOW_S
-            ):
-                return
-            if frame_epoch is None and lp is not None:
-                frame_epoch = lp.get("frame_epoch")
+            reason = self._pose_reject_reason(lp, epoch)
+            if reason is not None:
+                self._pose_rejects[reason] += 1
+                self._pose_consecutive_rejects += 1
+                n = self._pose_consecutive_rejects
+                if n in (1, 100, 1000, 10000) or (n > 10000 and n % 100000 == 0):
+                    logger.warning(
+                        "[WM] robot_pose: write rejected (%s; %d consecutive): writer epoch=%s vs stored epoch=%s. "
+                        "Only a second writer can produce this -- every shipped receiver writes at receive "
+                        "time with its own epoch.", reason, n, epoch, lp.get("frame_epoch"),
+                    )
+                return False
+            self._pose_consecutive_rejects = 0
+            if lp is not None and self._pose_is_regression(lp, epoch, ts, s_ns):
+                self._pose_regressions += 1
+                if now_mono - self._pose_last_regression_warn_mono >= self._POSE_REGRESSION_WARN_EVERY_S:
+                    self._pose_last_regression_warn_mono = now_mono
+                    logger.warning(
+                        "[WM] robot_pose: pose key went backwards within epoch %s (sensor stamp %s -> %s, "
+                        "timestamp %.3f -> %.3f; %d regression(s) so far): the sender restarted or stepped its "
+                        "clock (looped replay, bag loop, bridge restart). The pose follows the sender; a new "
+                        "session would bump frame_epoch instead.",
+                        epoch, lp.get("sensor_ts_ns"), s_ns, float(lp["timestamp"]), ts, self._pose_regressions,
+                    )
+            self._pose_writes_accepted += 1
+            clock = pose_clock if pose_clock is not None else (lp.get("pose_clock") if lp else None)
             self._latest_pose = {
                 "xyz": t_wc.tolist() if hasattr(t_wc, 'tolist') else list(t_wc),
                 "quaternion_xyzw": q_wc_xyzw.tolist() if hasattr(q_wc_xyzw, 'tolist') else list(q_wc_xyzw),
                 "timestamp": ts,
-                "frame_epoch": frame_epoch,
+                "frame_epoch": epoch,
+                "sensor_ts_ns": s_ns,
+                "pose_clock": clock,
             }
             self._latest_pose_arrival_mono = now_mono
+            return True
+
+    @classmethod
+    def _pose_reject_reason(cls, lp: Optional[Dict[str, Any]], epoch: Optional[int]) -> Optional[str]:
+        """Second-writer safety net; None = accept."""
+        if lp is None:
+            return None
+        lp_epoch = lp.get("frame_epoch")
+        if epoch is None:
+            return cls.POSE_REJECT_EPOCHLESS if lp_epoch is not None else None
+        if lp_epoch is not None and epoch < lp_epoch:
+            return cls.POSE_REJECT_OLDER_EPOCH
+        return None
+
+    @staticmethod
+    def _pose_is_regression(lp: Dict[str, Any], epoch: Optional[int], ts: float, s_ns: Optional[int]) -> bool:
+        """Same epoch (or both epoch-less) and the ordering key went backwards."""
+        lp_epoch = lp.get("frame_epoch")
+        if epoch != lp_epoch:
+            return False            # a new session (epoch above) or the first epoch: a restart, not a regression
+        lp_s = lp.get("sensor_ts_ns")
+        if s_ns is not None and lp_s is not None:
+            return s_ns < int(lp_s)
+        return ts < float(lp["timestamp"])
+
+    def _robot_pose_payload(self) -> Optional[Dict[str, Any]]:
+        """The stored pose plus read-time diagnostics: age_s on this process's
+        clock since the last accepted write (never wall-now minus a sender
+        stamp), the stale flag, and the mailbox counters. Built under the WM
+        lock (no torn read); a fresh dict each call (callers may mutate)."""
+        with self._lock:
+            lp = self._latest_pose
+            if lp is None:
+                return None
+            age = max(0.0, time.monotonic() - self._latest_pose_arrival_mono)
+            out = dict(lp)
+            out["xyz"] = list(lp["xyz"])
+            out["quaternion_xyzw"] = list(lp["quaternion_xyzw"])
+            out["age_s"] = round(age, 3)
+            out["stale"] = bool(age > self._pose_stale_after_s)
+            out["stale_after_s"] = self._pose_stale_after_s
+            out["writes_accepted"] = int(self._pose_writes_accepted)
+            out["sensor_ts_regressions"] = int(self._pose_regressions)
+            out["rejected_writes"] = int(sum(self._pose_rejects.values()))
+            out["rejected_by_reason"] = dict(self._pose_rejects)
+            return out
 
     def get_robot_pose(self) -> Optional[Dict[str, Any]]:
-        """Get the latest robot pose, or None if no frame has arrived yet
-        (live websocket: first *received* frame; ZMQ/replay: first
-        *processed* frame)."""
-        return self._latest_pose
+        """The latest robot pose with diagnostics (see _robot_pose_payload), or
+        None if no pose has arrived yet. Written at receive time by every
+        receiver (P1 tasks 2 and 4); the pipeline does not write it."""
+        return self._robot_pose_payload()
 
     def set_forward_clearance(self, clearance_m: float, valid_frac: float,
                               timestamp: float) -> None:
@@ -953,7 +1071,7 @@ class WorkingMemory:
                 "avg_hits": avg_hits,
                 "upserts_total": int(self._upsert_count_total),
                 "ltm_never_upserted": never_upserted,
-                "robot_pose": self._latest_pose,
+                "robot_pose": self._robot_pose_payload(),
                 "detections_by_label": {
                     k: dict(v) for k, v in self._label_detections.items()
                 },
@@ -997,11 +1115,17 @@ class WorkingMemory:
             if self.index is not None:
                 self.index.clear()
 
-            # Reset stored robot pose so the monotonic-timestamp guard in
-            # update_robot_pose() can't reject re-fed older timestamps
-            # (e.g. replaying a recording after a /reset).
+            # Reset the robot-pose mailbox so re-fed older stamps (replaying a
+            # recording after a /reset, a rig restart) are accepted again, and
+            # zero its counters.
             self._latest_pose = None
             self._latest_pose_arrival_mono = 0.0
+            self._pose_writes_accepted = 0
+            for k in self._pose_rejects:
+                self._pose_rejects[k] = 0
+            self._pose_consecutive_rejects = 0
+            self._pose_regressions = 0
+            self._pose_last_regression_warn_mono = float("-inf")
             # Drop the last clearance sample too (stale after a reset).
             self._latest_clearance = None
 

--- a/scripts/compare_demo_configs.py
+++ b/scripts/compare_demo_configs.py
@@ -116,6 +116,7 @@ def run_config(config_name: str, replay_dir: str) -> dict:
         require_tracking_normal=bool(ws_cfg.get("require_tracking_normal", True)),
         keyframe_every_n=int(ws_cfg.get("keyframe_every_n", 30)),
         nonkf_min_interval_s=float(ws_cfg.get("nonkf_min_interval_s", 0.5)),
+        pose_sink=wm.update_robot_pose,   # receive-time pose (the pipeline no longer writes it)
         confidence_threshold=int(ws_cfg.get("confidence_threshold", 1)),
         apply_camera_flip=bool(vis_cfg.get("apply_camera_flip", False)),
         throttle_clock=clock_mode,

--- a/tests/test_admit_before_decode.py
+++ b/tests/test_admit_before_decode.py
@@ -160,7 +160,7 @@ class TestReplayerAdmission:
         q = IngestQueue(maxsize=1)                       # room for exactly one frame; nobody drains it
         rr = ReplayReceiver(recording_dir=str(rec_dir), ingest_queue=q, keyframe_every_n=30,
                             nonkf_min_interval_s=0.0, replay_speed=10.0,
-                            on_camera_frame=broadcasts.append, pose_sink=lambda *a: poses.append(a),
+                            on_camera_frame=broadcasts.append, pose_sink=lambda *a, **kw: poses.append((a, kw)),
                             event_sink=events.append)
         rr.start()
         assert rr.wait(10.0)
@@ -169,7 +169,9 @@ class TestReplayerAdmission:
         assert len(broadcasts) == 1                      # viz saw the admitted frame only
         assert count_rgb_decodes["n"] == 1               # the two refused frames were never RGB-decoded
         assert len(poses) == 3                           # pose sink fired for every tracking-normal frame
-        assert all(len(p) == 4 for p in poses)           # (t_wc, q_xyzw, unix_ts, frame_epoch)
+        assert all(len(a) == 4 for a, _ in poses)        # (t_wc, q_xyzw, unix_ts, frame_epoch)
+        assert [kw["sensor_ts_ns"] for _, kw in poses] == [1000, 2000, 3000]   # + the mailbox key (P1 task 4)
+        assert all(kw["pose_clock"] == "sender" for _, kw in poses)
 
     def test_bad_depth_frame_does_not_hang_the_replayer(self, tmp_path, monkeypatch):
         """The depth decode now runs before the throttle / admission for every

--- a/tests/test_demo_entrypoint.py
+++ b/tests/test_demo_entrypoint.py
@@ -1,0 +1,54 @@
+"""`rtsm demo` startup validation runs BEFORE any model loads and its imports
+are bound before their first use (a function-local import placed after the
+validation block left `LaneConfig` an unbound local: `rtsm demo` crashed at
+startup on main between PR #33 and P1 task 4). CPU-only: a deliberately bad
+config value must exit through parser.error, which proves the block ran with
+its names bound and never reached the segmentation loader.
+"""
+from __future__ import annotations
+
+import pytest
+
+import rtsm.demo as demo
+
+
+@pytest.fixture
+def no_models(monkeypatch, tmp_path):
+    monkeypatch.setattr(demo, "_find_demo_data", lambda: str(tmp_path))
+
+    def boom(*a, **k):
+        raise AssertionError("model loading must not be reached when the config is invalid")
+    import rtsm.models.segmentation as seg
+    monkeypatch.setattr(seg, "get_segmenter", boom)
+
+
+@pytest.mark.parametrize("bad", [
+    "robot_pose.stale_after_s=0",
+    "ingest.policy=newest",
+    "ingest.keyframe_lane_depth=0",
+])
+def test_bad_ingest_or_pose_config_exits_before_model_load(no_models, bad, capsys):
+    with pytest.raises(SystemExit) as ex:
+        demo.run_demo(["--no-viz", "--set", bad])
+    assert ex.value.code == 2                                    # argparse parser.error
+    err = capsys.readouterr().err
+    assert "robot_pose" in err or "ingest" in err
+
+
+def test_validation_names_are_bound_before_use():
+    """Static pin: the two validators must not be function-local names that are
+    assigned only after the validation block (Python would compile the early
+    reference as an unbound local)."""
+    import dis
+    code = demo.run_demo.__code__
+    first_load, first_store = {}, {}
+    for ins in dis.get_instructions(code):
+        if ins.argval in ("LaneConfig", "resolve_pose_stale_after_s"):
+            if ins.opname.startswith("LOAD_") and ins.argval not in first_load:
+                first_load[ins.argval] = ins.offset
+            if ins.opname.startswith("STORE_") and ins.argval not in first_store:
+                first_store[ins.argval] = ins.offset
+    for name in ("LaneConfig", "resolve_pose_stale_after_s"):
+        assert name in first_load, name
+        if name in first_store:                                   # function-local import: must precede the load
+            assert first_store[name] < first_load[name], f"{name} is used before its import binds it"

--- a/tests/test_pose_mailbox.py
+++ b/tests/test_pose_mailbox.py
@@ -1,0 +1,355 @@
+"""Robot-pose mailbox (Gate 4.5 plan, P1 task 4): one receive-time writer per
+process (the pipeline no longer writes the pose); writes are keyed on
+(frame_epoch, sensor_ts_ns) as a REGRESSION DETECTOR (a stamp going backwards
+within an epoch is accepted and counted, never used to freeze the pose);
+only a second writer can be rejected (older epoch, epoch-less into an epoch);
+the payload carries age_s / stale / pose_clock / counters; the websocket sink
+passes the sensor stamp and a sender|server clock tag; ZeroMQ writes the pose
+at receive time for tracking poses with a receiver-minted epoch, and a
+stamp-less kf_pose inherits the last tracking stamp. CPU-only.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+import struct
+
+import cv2
+import numpy as np
+import pytest
+
+from rtsm.io.ingest_queue import IngestQueue
+from rtsm.stores.working_memory import WorkingMemory, resolve_pose_stale_after_s
+
+T = np.array([1.0, 2.0, 3.0])
+Q = np.array([0.0, 0.0, 0.0, 1.0])
+LOG = "rtsm.stores.working_memory"
+
+
+def _wm(**cfg) -> WorkingMemory:
+    return WorkingMemory(cfg=cfg)
+
+
+def _xyz(wm):
+    return wm.get_robot_pose()["xyz"]
+
+
+# ── the rule ─────────────────────────────────────────────────────────────────
+
+class TestSingleWriterRule:
+    def test_older_stamp_is_accepted_and_counted_as_a_regression(self):
+        """No time window and no rejection: the single writer says this is the
+        pose now (looped replay, bag loop, stepped clock)."""
+        wm = _wm()
+        assert wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), Q, 1000.0, frame_epoch=0, sensor_ts_ns=1000)
+        wm._latest_pose_arrival_mono -= 60.0
+        assert wm.update_robot_pose(T, Q, 10.0, frame_epoch=0, sensor_ts_ns=10) is True
+        p = wm.get_robot_pose()
+        assert (p["xyz"], p["sensor_ts_ns"]) == ([1.0, 2.0, 3.0], 10)
+        assert (p["sensor_ts_regressions"], p["rejected_writes"], p["writes_accepted"]) == (1, 0, 2)
+
+    def test_new_epoch_with_a_smaller_stamp_is_not_a_regression(self):
+        wm = _wm()
+        assert wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), Q, 1000.0, frame_epoch=1, sensor_ts_ns=1000)
+        assert wm.update_robot_pose(T, Q, 10.0, frame_epoch=2, sensor_ts_ns=10)
+        p = wm.get_robot_pose()
+        assert (p["xyz"], p["frame_epoch"], p["sensor_ts_ns"], p["sensor_ts_regressions"]) == ([1.0, 2.0, 3.0], 2, 10, 0)
+
+    def test_older_epoch_is_rejected_even_with_a_larger_stamp(self):
+        """Only a second writer can do this (a drained previous-session frame)."""
+        wm = _wm()
+        assert wm.update_robot_pose(T, Q, 10.0, frame_epoch=2, sensor_ts_ns=10)
+        assert wm.update_robot_pose(np.array([9.0, 9.0, 9.0]), Q, 5000.0, frame_epoch=1, sensor_ts_ns=5000) is False
+        p = wm.get_robot_pose()
+        assert p["frame_epoch"] == 2 and p["rejected_by_reason"]["older_epoch"] == 1 and p["rejected_writes"] == 1
+
+    def test_epochless_write_into_an_epoch_mailbox_is_rejected_and_epoch_unchanged(self):
+        wm = _wm()
+        assert wm.update_robot_pose(T, Q, 100.0, frame_epoch=2, sensor_ts_ns=100)
+        assert wm.update_robot_pose(np.array([7.0, 8.0, 9.0]), Q, 1000.0, sensor_ts_ns=1000) is False
+        p = wm.get_robot_pose()
+        assert p["xyz"] == [1.0, 2.0, 3.0] and p["frame_epoch"] == 2
+        assert p["rejected_by_reason"]["epochless_into_epoch"] == 1
+
+    def test_first_epoch_bearing_write_adopts_the_epoch(self):
+        wm = _wm()
+        assert wm.update_robot_pose(T, Q, 100.0, sensor_ts_ns=100)                       # epoch-less first
+        assert wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), Q, 50.0, frame_epoch=1, sensor_ts_ns=50)
+        p = wm.get_robot_pose()
+        assert p["frame_epoch"] == 1 and p["sensor_ts_regressions"] == 0               # adopted, not a regression
+
+    def test_equal_key_is_accepted_and_keeps_the_stored_clock_tag(self):
+        wm = _wm()
+        assert wm.update_robot_pose(T, Q, 100.0, frame_epoch=0, sensor_ts_ns=100, pose_clock="sender")
+        assert wm.update_robot_pose(np.array([1.5, 2.5, 3.5]), Q, 100.0, frame_epoch=0, sensor_ts_ns=100)
+        p = wm.get_robot_pose()
+        assert p["xyz"] == [1.5, 2.5, 3.5] and p["pose_clock"] == "sender" and p["sensor_ts_regressions"] == 0
+
+    def test_regressions_are_detected_on_the_sensor_stamp_not_the_wall_timestamp(self):
+        wm = _wm()
+        assert wm.update_robot_pose(T, Q, 5.0, frame_epoch=0, sensor_ts_ns=200)
+        assert wm.update_robot_pose(T, Q, 999.0, frame_epoch=0, sensor_ts_ns=100)      # stamp back: regression
+        assert wm.update_robot_pose(T, Q, 1.0, frame_epoch=0, sensor_ts_ns=300)        # wall back, stamp forward: fine
+        assert wm.get_robot_pose()["sensor_ts_regressions"] == 1
+
+    def test_wall_timestamp_is_the_key_without_sensor_stamps_and_zero_counts_as_none(self):
+        wm = _wm()
+        assert wm.update_robot_pose(T, Q, 100.0) and wm.update_robot_pose(T, Q, 99.0)  # timestamp regression
+        assert wm.get_robot_pose()["sensor_ts_regressions"] == 1
+        assert wm.update_robot_pose(T, Q, 101.0, sensor_ts_ns=0)                        # 0 = no stamp
+        assert wm.get_robot_pose()["sensor_ts_ns"] is None
+        assert wm.update_robot_pose(T, Q, 100.5, sensor_ts_ns=0)                        # judged on the timestamp
+        assert wm.get_robot_pose()["sensor_ts_regressions"] == 2
+
+    def test_looped_sender_keeps_the_pose_advancing_and_warns_once_per_minute(self, caplog):
+        """The G1-C shape: session1 streamed in a loop behind one handshake.
+        Every write is accepted, one regression per wrap, one WARNING."""
+        wm = _wm()
+        with caplog.at_level(logging.WARNING, logger=LOG):
+            for loop in range(3):
+                for i in range(5):
+                    assert wm.update_robot_pose(np.array([float(loop), float(i), 0.0]), Q, 1000.0 + loop * 5 + i,
+                                                frame_epoch=0, sensor_ts_ns=1_000 + i * 100)
+        p = wm.get_robot_pose()
+        assert (p["writes_accepted"], p["sensor_ts_regressions"], p["rejected_writes"]) == (15, 2, 0)
+        assert p["xyz"] == [2.0, 4.0, 0.0]                                              # follows the sender
+        assert sum(1 for r in caplog.records if "pose key went backwards" in r.getMessage()) == 1
+
+    def test_second_writer_rejections_warn_with_backoff(self, caplog):
+        wm = _wm()
+        assert wm.update_robot_pose(T, Q, 100.0, frame_epoch=2, sensor_ts_ns=100)
+        with caplog.at_level(logging.WARNING, logger=LOG):
+            for i in range(1000):
+                assert wm.update_robot_pose(T, Q, 200.0 + i, sensor_ts_ns=200 + i) is False
+        assert wm.get_robot_pose()["rejected_by_reason"]["epochless_into_epoch"] == 1000
+        assert sum(1 for r in caplog.records if "write rejected" in r.getMessage()) == 3       # at 1, 100, 1000
+
+
+# ── payload, config, reset ───────────────────────────────────────────────────
+
+class TestPayload:
+    def test_age_stale_and_counters(self):
+        wm = _wm(robot_pose={"stale_after_s": 0.5})
+        assert wm.get_robot_pose() is None and wm.stats()["robot_pose"] is None
+        wm.update_robot_pose(T, Q, 100.0, frame_epoch=0, sensor_ts_ns=100, pose_clock="sender")
+        p = wm.get_robot_pose()
+        assert p["stale"] is False and p["age_s"] < 0.5 and p["stale_after_s"] == 0.5 and p["pose_clock"] == "sender"
+        assert (p["writes_accepted"], p["rejected_writes"], p["sensor_ts_regressions"]) == (1, 0, 0)
+        wm._latest_pose_arrival_mono -= 2.0
+        p = wm.get_robot_pose()
+        assert p["stale"] is True and 1.9 < p["age_s"] < 3.0
+        assert wm.stats()["robot_pose"]["stale"] is True                        # same builder behind /stats
+
+    def test_payload_is_a_copy(self):
+        wm = _wm()
+        wm.update_robot_pose(T, Q, 100.0, sensor_ts_ns=100)
+        wm.get_robot_pose()["xyz"].append(99.0)
+        assert _xyz(wm) == [1.0, 2.0, 3.0]
+
+    def test_payload_is_json_serialisable_with_numpy_inputs(self):
+        wm = _wm()
+        wm.update_robot_pose(np.float32([1, 2, 3]), np.float32([0, 0, 0, 1]), np.float64(100.0),
+                             frame_epoch=np.int64(2), sensor_ts_ns=np.int64(5))
+        p = wm.get_robot_pose()
+        json.dumps(p)
+        assert (p["frame_epoch"], p["sensor_ts_ns"]) == (2, 5) and type(p["frame_epoch"]) is int
+
+    def test_stale_threshold_is_validated_not_coerced(self):
+        assert resolve_pose_stale_after_s({}) == 0.5
+        assert resolve_pose_stale_after_s({"robot_pose": {"stale_after_s": None}}) == 0.5
+        assert resolve_pose_stale_after_s({"robot_pose": {"stale_after_s": "1.5"}}) == 1.5
+        for bad in (0, -1, "x", True, float("inf")):
+            with pytest.raises(ValueError, match="robot_pose.stale_after_s"):
+                resolve_pose_stale_after_s({"robot_pose": {"stale_after_s": bad}})
+        with pytest.raises(ValueError, match="robot_pose must be a mapping"):
+            resolve_pose_stale_after_s({"robot_pose": 0.5})                      # the obvious one-key typo
+        with pytest.raises(ValueError):
+            WorkingMemory(cfg={"robot_pose": {"stale_after_s": 0}})
+
+    def test_clear_resets_mailbox_and_counters(self):
+        wm = _wm()
+        wm.update_robot_pose(T, Q, 1000.0, frame_epoch=5, sensor_ts_ns=1000)
+        wm.update_robot_pose(T, Q, 1.0, frame_epoch=5, sensor_ts_ns=1)                 # regression
+        assert wm.update_robot_pose(T, Q, 1.0, sensor_ts_ns=1) is False                # epoch-less: rejected
+        wm.clear()
+        assert wm.get_robot_pose() is None
+        assert wm.update_robot_pose(np.array([7.0, 8.0, 9.0]), Q, 5.0, sensor_ts_ns=5)
+        p = wm.get_robot_pose()
+        assert (p["writes_accepted"], p["rejected_writes"], p["sensor_ts_regressions"], p["frame_epoch"]) == (1, 0, 0, None)
+
+
+# ── websocket sink + no pipeline write ───────────────────────────────────────
+
+def _ws_frame(frame_id: int, timestamp_ns: int, unix_ts=1700000000.0, with_unix=True, T_wc=(0.0, 0.0, 0.0)) -> bytes:
+    rgb = np.zeros((8, 8, 3), dtype=np.uint8); _, jpeg = cv2.imencode(".jpg", rgb)
+    depth = np.ones((8, 8), dtype=np.uint16) * 1500
+    header = {"frame_id": frame_id, "timestamp_ns": timestamp_ns,
+              "rgb_format": "jpeg", "rgb_width": 8, "rgb_height": 8,
+              "depth_format": "uint16_mm", "depth_width": 8, "depth_height": 8, "depth_scale": 0.001,
+              "fx": 5.0, "fy": 5.0, "cx": 4.0, "cy": 4.0,
+              "pose_format": "quat_translation", "T_wc": [0.0, 0.0, 0.0, 1.0, *T_wc], "tracking_state": "normal"}
+    if with_unix:
+        header["unix_timestamp"] = unix_ts
+    hj = json.dumps(header).encode(); rj = jpeg.tobytes(); dj = depth.tobytes()
+    return struct.pack("<I", len(hj)) + hj + struct.pack("<I", len(rj)) + rj + struct.pack("<I", len(dj)) + dj
+
+
+class TestWebSocketSink:
+    def test_sink_gets_sensor_stamp_and_clock_tag(self):
+        from rtsm.io.websocket import WebSocketReceiver
+        calls = []
+        recv = WebSocketReceiver(ingest_queue=IngestQueue(maxsize=8), keyframe_every_n=1000, nonkf_min_interval_s=0.0,
+                                 pose_sink=lambda t, q, ts, ep, **kw: calls.append((ts, ep, kw)))
+        recv._note_session("A")
+        recv._parse_binary_message(_ws_frame(1, 5_000, unix_ts=123.5))
+        recv._parse_binary_message(_ws_frame(2, 6_000, with_unix=False))
+        recv._parse_binary_message(_ws_frame(3, 0))                                      # zero stamp -> None
+        (ts1, ep1, kw1), (ts2, ep2, kw2), (_, _, kw3) = calls
+        assert (ts1, ep1, kw1) == (123.5, 1, {"sensor_ts_ns": 5_000, "pose_clock": "sender"})
+        assert ep2 == 1 and kw2 == {"sensor_ts_ns": 6_000, "pose_clock": "server"} and ts2 > 1e9   # time.time() substituted
+        assert kw3["sensor_ts_ns"] is None
+
+    def test_receive_time_writes_end_to_end_and_the_pipeline_never_writes(self):
+        from rtsm.core import pipeline as pipeline_mod
+        from rtsm.io.websocket import WebSocketReceiver
+        assert ".update_robot_pose(" not in inspect.getsource(pipeline_mod), \
+            "the pipeline must not write the robot pose: the receivers do, at receive time (P1 task 4)"
+        wm = _wm()
+        recv = WebSocketReceiver(ingest_queue=IngestQueue(maxsize=8), keyframe_every_n=1000, nonkf_min_interval_s=0.0,
+                                 pose_sink=wm.update_robot_pose)
+        recv._note_session("A")
+        recv._parse_binary_message(_ws_frame(1, 1_000, unix_ts=100.0, T_wc=(1.0, 0.0, 0.0)))
+        recv._parse_binary_message(_ws_frame(2, 2_000, unix_ts=101.0, T_wc=(2.0, 0.0, 0.0)))
+        p = wm.get_robot_pose()
+        assert p["xyz"][0] == pytest.approx(2.0) and (p["frame_epoch"], p["sensor_ts_ns"], p["pose_clock"]) == (1, 2_000, "sender")
+        assert (p["writes_accepted"], p["sensor_ts_regressions"], p["rejected_writes"]) == (2, 0, 0)
+
+
+# ── ZeroMQ: receive-time sink, receiver-minted epoch, stamp inheritance ──────
+
+class TestZeroMQPose:
+    def _sub(self, sink):
+        pytest.importorskip("zmq")
+        from rtsm.io.zeromq import ZeroMQSubscriber
+        return ZeroMQSubscriber(camera_endpoint="tcp://127.0.0.1:1", rtabmap_endpoint="tcp://127.0.0.1:1",
+                                ingest_queue=IngestQueue(maxsize=8), pose_sink=sink)
+
+    @staticmethod
+    def _msg(topic: str, **fields) -> list:
+        return [topic.encode(), json.dumps(fields).encode()]
+
+    @staticmethod
+    def _camera_msg(ts_ns: int) -> list:
+        rgb = np.full((8, 8, 3), 90, dtype=np.uint8); _, jpg = cv2.imencode(".jpg", rgb)
+        _, png = cv2.imencode(".png", np.ones((8, 8), dtype=np.uint16) * 1234)
+        meta = {"ts_ns": ts_ns, "intrinsics": {"fx": 5.0, "fy": 5.0, "cx": 4.0, "cy": 4.0, "width": 8, "height": 8},
+                "depth_units_m": 0.001}
+        return [b"camera.rgbd", json.dumps(meta).encode(), jpg.tobytes(), png.tobytes()]
+
+    def test_tracking_poses_write_at_receive_time_and_keyframes_do_not(self):
+        wm = _wm(); calls = []
+
+        def sink(t, q, ts, ep, **kw):
+            calls.append((ep, kw)); return wm.update_robot_pose(t, q, ts, ep, **kw)
+        sub = self._sub(sink)
+        try:
+            base_ms = 1_700_000_000_000
+            for i in range(30):
+                sub._handle_tracking_pose(self._msg("rtabmap.tracking_pose", stamp_ms=base_ms + i * 33,
+                                                    T_wc=[0.1 * i, 0.0, 0.0, 0.0, 0.0, 0.0]))
+            enq = []
+            real = sub._try_enqueue_frame
+            sub._try_enqueue_frame = lambda ts, t, q, is_keyframe: (enq.append((ts, is_keyframe)), real(ts, t, q, is_keyframe))[1]
+            sub._handle_kf_pose(self._msg("rtabmap.kf_pose", kf_id=4, T_wc=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+            assert len(calls) == 30                                                      # kf_pose: no pose write
+            assert all(ep == 0 and kw["pose_clock"] == "server" for ep, kw in calls)
+            assert [kw["sensor_ts_ns"] for _, kw in calls] == [(base_ms + i * 33) * 1_000_000 for i in range(30)]
+            assert enq == [((base_ms + 29 * 33) * 1_000_000, True)]                       # inherited the last tracking stamp
+            assert sub._kf_stamps_inherited == 1 and sub.liveness()["kf_stamps_inherited"] == 1
+            p = wm.get_robot_pose()
+            assert (p["writes_accepted"], p["sensor_ts_regressions"], p["rejected_writes"], p["frame_epoch"]) == (30, 0, 0, 0)
+            assert p["xyz"][0] == pytest.approx(2.9)
+            sub._handle_tracking_pose(self._msg("rtabmap.tracking_pose", T_wc=[0, 0, 0, 0, 0, 0]))   # stamp-less TRACKING pose
+            assert sub._kf_stamps_inherited == 1                                            # ...is not a keyframe stamp
+        finally:
+            sub.close()
+
+    def test_stamp_jumping_back_over_five_seconds_mints_a_new_epoch(self):
+        """A bag loop / bridge restart: every write accepted, epoch 0 -> 1, no
+        regression counted (a new epoch is a restart), FramePacket carries it."""
+        wm = _wm(); epochs = []
+        sub = self._sub(lambda t, q, ts, ep, **kw: (epochs.append(ep), wm.update_robot_pose(t, q, ts, ep, **kw))[1])
+        try:
+            sub._nonkf_min_interval_s = 0.0
+            for i in range(300):
+                sub._handle_tracking_pose(self._msg("rtabmap.tracking_pose", stamp_ms=10_000 + i * 33, T_wc=[0, 0, 0, 0, 0, 0]))
+            for i in range(300):                                                          # wrap: ~9 s back (a 0 stamp would be "no stamp")
+                sub._handle_tracking_pose(self._msg("rtabmap.tracking_pose", stamp_ms=1_000 + i * 33, T_wc=[0, 0, 0, 0, 0, 0]))
+            assert epochs == [0] * 300 + [1] * 300 and sub.liveness()["frame_epoch"] == 1
+            p = wm.get_robot_pose()
+            assert (p["writes_accepted"], p["sensor_ts_regressions"], p["rejected_writes"], p["frame_epoch"]) == (600, 0, 0, 1)
+            ts = (1_000 + 300 * 33) * 1_000_000
+            sub._handle_camera_rgbd(self._camera_msg(ts))
+            sub._handle_tracking_pose(self._msg("rtabmap.tracking_pose", stamp_ms=1_000 + 300 * 33, T_wc=[0, 0, 0, 0, 0, 0]))
+            pkt = sub.ingest_q.get()
+            assert pkt is not None and pkt.frame_epoch == 1                              # the packet carries the epoch
+        finally:
+            sub.close()
+
+    def test_zero_stamp_neither_bumps_the_epoch_nor_becomes_the_reference(self):
+        wm = _wm()
+        sub = self._sub(wm.update_robot_pose)
+        try:
+            for ms in (5_000, 0, 5_033):                                              # an uninitialised ROS header in between
+                sub._handle_tracking_pose(self._msg("rtabmap.tracking_pose", stamp_ms=ms, T_wc=[0, 0, 0, 0, 0, 0]))
+            p = wm.get_robot_pose()
+            assert (sub.liveness()["frame_epoch"], p["frame_epoch"], p["sensor_ts_regressions"], p["writes_accepted"]) == (0, 0, 0, 3)
+            assert sub._last_pose_ts_ns == 5_033_000_000
+        finally:
+            sub.close()
+
+    def test_small_backwards_step_is_a_regression_not_an_epoch(self):
+        wm = _wm()
+        sub = self._sub(wm.update_robot_pose)
+        try:
+            sub._handle_tracking_pose(self._msg("rtabmap.tracking_pose", stamp_ms=5_000, T_wc=[0, 0, 0, 0, 0, 0]))
+            sub._handle_tracking_pose(self._msg("rtabmap.tracking_pose", stamp_ms=4_000, T_wc=[0, 0, 0, 0, 0, 0]))   # 1 s back
+            p = wm.get_robot_pose()
+            assert (p["frame_epoch"], p["sensor_ts_regressions"], p["writes_accepted"]) == (0, 1, 2)
+        finally:
+            sub.close()
+
+    def test_stampless_keyframe_fallback_chain_and_duplicate_image_avoidance(self, monkeypatch):
+        sub = self._sub(None)
+        try:
+            import rtsm.io.zeromq as zmod
+            monkeypatch.setattr(zmod.time, "time_ns", lambda: 777)
+            ts, *_ = sub._parse_rtabmap_pose({"T_wc": [0, 0, 0, 0, 0, 0]})
+            assert ts == 777                                                              # nothing on the sensor clock yet
+            sub.fw.watermark = 4_000_000_000
+            ts, *_ = sub._parse_rtabmap_pose({"T_wc": [0, 0, 0, 0, 0, 0]})
+            assert ts == 4_000_000_000                                                    # newest camera frame
+            sub._last_pose_ts_ns = 3_000_000_000
+            ts, *_ = sub._parse_rtabmap_pose({"T_wc": [0, 0, 0, 0, 0, 0]})
+            assert ts == 3_000_000_000                                                    # last tracking stamp wins
+            # ...unless the image that tracking pose was PAIRED with (nearest camera
+            # stamp, here 2.99 s for a 3.0 s pose) was already enqueued and a newer frame exists
+            sub._handle_camera_rgbd(self._camera_msg(2_990_000_000)); sub._handle_camera_rgbd(self._camera_msg(4_000_000_000))
+            sub._last_enq_cam_ts = 2_990_000_000
+            ts, *_ = sub._parse_rtabmap_pose({"T_wc": [0, 0, 0, 0, 0, 0]})
+            assert ts == 4_000_000_000                                                    # then the newest frame
+            sub._last_enq_cam_ts = None
+            ts, *_ = sub._parse_rtabmap_pose({"T_wc": [0, 0, 0, 0, 0, 0]})
+            assert ts == 3_000_000_000                                                    # not enqueued -> tracking stamp
+            ts, *_ = sub._parse_rtabmap_pose({"stamp_ms": 6_000, "T_wc": [0, 0, 0, 0, 0, 0]})
+            assert ts == 6_000_000_000                                                    # own stamp always wins
+        finally:
+            sub.close()
+
+    def test_no_sink_is_safe(self):
+        sub = self._sub(None)
+        try:
+            sub._handle_tracking_pose(self._msg("rtabmap.tracking_pose", stamp_ms=1, T_wc=[0, 0, 0, 0, 0, 0]))
+        finally:
+            sub.close()

--- a/tests/test_pose_receive_time.py
+++ b/tests/test_pose_receive_time.py
@@ -1,15 +1,9 @@
-"""
-Tests for receive-time robot pose passthrough.
-
-Covers:
-- WorkingMemory.update_robot_pose monotonic-timestamp guard (a slow pipeline
-  write must not overwrite a fresher receive-time pose) and clear() reset.
-- WebSocketReceiver pose_sink firing at input rate — including frames the
-  keyframe/interval throttle skips — with the same post-flip pose the
-  FramePacket carries.
-- Frame epoch: bumps when a hello carries a new session_id (sender re-created
-  its streaming session → world origin may have moved), rides the pose sink,
-  and is preserved by epoch-less writers (pipeline dual-write).
+"""Robot-pose receive-time path: the websocket pose sink fires for every
+tracking-normal frame (throttled ones included) with the post-convention pose,
+the frame epoch bumps on a new session, and WorkingMemory.update_robot_pose is
+the single-writer MAILBOX (P1 task 4): a same-epoch older stamp is accepted and
+counted as a regression; only an older-epoch or epoch-less write is rejected
+(second-writer safety net). See tests/test_pose_mailbox.py for the full table.
 """
 
 from __future__ import annotations
@@ -29,7 +23,7 @@ from rtsm.stores.working_memory import WorkingMemory
 # ─────────────────── update_robot_pose guard ───────────────────
 
 
-class TestUpdateRobotPoseGuard:
+class TestUpdateRobotPoseMailbox:
     def _wm(self) -> WorkingMemory:
         return WorkingMemory(cfg={})
 
@@ -47,37 +41,39 @@ class TestUpdateRobotPoseGuard:
         wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), np.array([0, 0, 0, 1.0]), 101.0)
         assert wm.get_robot_pose()["xyz"] == [4.0, 5.0, 6.0]
 
-    def test_older_rejected(self):
-        """The pipeline writes the pose of an already-processed (older) frame;
-        it must not stomp a fresher receive-time pose."""
+    def test_older_accepted_and_counted_as_a_regression(self):
+        """P1 task 4: there is ONE writer (the receiver, at receive time; the
+        pipeline no longer writes the pose), so an older stamp is the sender
+        restarting or stepping its clock. It is accepted -- the pose follows
+        the sender -- and counted as a regression for diagnostics."""
         wm = self._wm()
         wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), np.array([0, 0, 0, 1.0]), 101.0)
-        wm.update_robot_pose(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0, 1.0]), 100.0)
+        assert wm.update_robot_pose(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0, 1.0]), 100.0) is True
         pose = wm.get_robot_pose()
-        assert pose["xyz"] == [4.0, 5.0, 6.0]
-        assert pose["timestamp"] == 101.0
+        assert pose["xyz"] == [1.0, 2.0, 3.0]
+        assert pose["timestamp"] == 100.0
+        assert pose["sensor_ts_regressions"] == 1 and pose["rejected_writes"] == 0
 
     def test_equal_timestamp_accepted(self):
-        """Same frame written twice (receiver then pipeline) is harmless."""
+        """The same frame written twice by the one writer is harmless."""
         wm = self._wm()
         wm.update_robot_pose(np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0, 1.0]), 100.0)
         wm.update_robot_pose(np.array([1.5, 2.5, 3.5]), np.array([0, 0, 0, 1.0]), 100.0)
         assert wm.get_robot_pose()["xyz"] == [1.5, 2.5, 3.5]
 
-    def test_older_accepted_after_staleness_window(self):
-        """A sender clock stepping backward (new device / NTP) must not
-        freeze the pose forever: once the stored pose is older than the
-        guard window, an older-timestamped update is accepted."""
+    def test_no_time_window_governs_acceptance(self):
+        """P1 task 4: the 2 s fail-open window is gone in both directions --
+        acceptance never depends on how long ago the stored pose arrived."""
         wm = self._wm()
         wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), np.array([0, 0, 0, 1.0]), 1000.0)
-        # Simulate the stored pose aging past the guard window.
-        wm._latest_pose_arrival_mono -= wm._POSE_GUARD_WINDOW_S + 1.0
-        wm.update_robot_pose(np.array([7.0, 8.0, 9.0]), np.array([0, 0, 0, 1.0]), 10.0)
+        wm._latest_pose_arrival_mono -= 60.0
+        assert wm.update_robot_pose(np.array([7.0, 8.0, 9.0]), np.array([0, 0, 0, 1.0]), 10.0) is True
         pose = wm.get_robot_pose()
-        assert pose["xyz"] == [7.0, 8.0, 9.0]
-        assert pose["timestamp"] == 10.0
+        assert pose["xyz"] == [7.0, 8.0, 9.0] and pose["sensor_ts_regressions"] == 1
+        assert wm.update_robot_pose(np.array([1.0, 1.0, 1.0]), np.array([0, 0, 0, 1.0]), 11.0) is True   # immediately, too
+        assert wm.get_robot_pose()["sensor_ts_regressions"] == 1
 
-    def test_clear_resets_guard(self):
+    def test_clear_resets_mailbox(self):
         """After clear() (e.g. /reset between replay runs or demo trials),
         older re-fed timestamps must be accepted again."""
         wm = self._wm()
@@ -139,7 +135,7 @@ class TestPoseSinkReceiveRate:
         """The key behavior: a frame the non-KF interval throttle skips
         (parse returns None, no image decode) still delivers its pose."""
         calls = []
-        rx = _make_receiver(lambda t, q, ts, ep: calls.append((t.copy(), np.asarray(q).copy(), ts)))
+        rx = _make_receiver(lambda t, q, ts, ep, **kw: calls.append((t.copy(), np.asarray(q).copy(), ts)))
         # Arm the throttle: pretend frame 1 was just enqueued.
         rx._frame_count = 1
         rx._last_nonkf_enq_mono = time.monotonic()
@@ -154,7 +150,7 @@ class TestPoseSinkReceiveRate:
 
     def test_sink_not_called_on_bad_tracking(self):
         calls = []
-        rx = _make_receiver(lambda t, q, ts, ep: calls.append(ts))
+        rx = _make_receiver(lambda t, q, ts, ep, **kw: calls.append(ts))
         hdr = _header()
         hdr["tracking_state"] = "limited"
         pkt = rx._parse_binary_message(_binary_message(hdr))
@@ -165,7 +161,7 @@ class TestPoseSinkReceiveRate:
         """The sink must deliver the same (post-convention) pose the
         FramePacket carries — one convention for all consumers."""
         calls = []
-        rx = _make_receiver(lambda t, q, ts, ep: calls.append((np.asarray(t).copy(), np.asarray(q).copy())))
+        rx = _make_receiver(lambda t, q, ts, ep, **kw: calls.append((np.asarray(t).copy(), np.asarray(q).copy())))
         img = np.zeros((2, 2, 3), dtype=np.uint8)
         _, jpeg = cv2.imencode(".jpg", img)
         pkt = rx._parse_binary_message(
@@ -183,7 +179,7 @@ class TestPoseSinkReceiveRate:
         calls_flip, calls_noflip = [], []
         for flip, calls in ((True, calls_flip), (False, calls_noflip)):
             rx = _make_receiver(
-                lambda t, q, ts, ep, c=calls: c.append((np.asarray(t).copy(), np.asarray(q).copy())),
+                lambda t, q, ts, ep, c=calls, **kw: c.append((np.asarray(t).copy(), np.asarray(q).copy())),
                 apply_camera_flip=flip,
             )
             rx._frame_count = 1
@@ -227,7 +223,7 @@ class TestFrameEpoch:
 
     def test_sink_receives_current_epoch(self):
         calls = []
-        rx = _make_receiver(lambda t, q, ts, ep: calls.append(ep))
+        rx = _make_receiver(lambda t, q, ts, ep, **kw: calls.append(ep))
         rx._note_session("A")
         rx._frame_count = 1
         rx._last_nonkf_enq_mono = time.monotonic()
@@ -236,19 +232,21 @@ class TestFrameEpoch:
         assert rx._parse_binary_message(_binary_message(_header(unix_ts=1235.5))) is None
         assert calls == [1, 2]
 
-    def test_wm_stores_epoch_and_none_preserves(self):
-        """The receiver writes with an epoch; the pipeline dual-writer calls
-        without one (None) and must NOT clear the stored epoch."""
+    def test_wm_stores_epoch_and_epochless_write_is_rejected(self):
+        """P1 task 4: the receiver writes with an epoch; a writer that knows
+        no epoch (legacy 3-arg call) is REJECTED against an epoch-bearing
+        pose -- it can neither clear nor bypass the epoch. (The pipeline no
+        longer writes the pose at all; this is the second-writer safety net.)"""
         wm = WorkingMemory(cfg={})
         wm.update_robot_pose(
             np.array([1.0, 2.0, 3.0]), np.array([0, 0, 0, 1.0]), 100.0, frame_epoch=3
         )
         assert wm.get_robot_pose()["frame_epoch"] == 3
-        # pipeline-style 3-arg write, newer timestamp → pose updates, epoch kept
-        wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), np.array([0, 0, 0, 1.0]), 101.0)
+        assert wm.update_robot_pose(np.array([4.0, 5.0, 6.0]), np.array([0, 0, 0, 1.0]), 101.0) is False
         pose = wm.get_robot_pose()
-        assert pose["xyz"] == [4.0, 5.0, 6.0]
+        assert pose["xyz"] == [1.0, 2.0, 3.0]
         assert pose["frame_epoch"] == 3
+        assert pose["rejected_by_reason"]["epochless_into_epoch"] == 1
         # next receiver write with a new epoch replaces it
         wm.update_robot_pose(
             np.array([7.0, 8.0, 9.0]), np.array([0, 0, 0, 1.0]), 102.0, frame_epoch=4


### PR DESCRIPTION
# Robot-pose mailbox: one receive-time writer, epoch-aware, no fail-open window (P1 task 4)

Execution plan `execution-plan-gate45-2026-09.md`, P1 task 4. `/stats.robot_pose` was written by two threads, the receiver at receive time and the pipeline after processing, and a 2 s fail-open guard decided which one won. After a stream stopped the pipeline's late writes of older frames were accepted once the window opened, so a dead feed could look alive, and a source that restarted its stamps had no defined behaviour. This PR makes the receiver the only writer, keys the store on the sender's session and sensor stamp, and turns what used to be a guard into diagnostics.

## What changes

- **One writer.** The pipeline's dequeue-time `update_robot_pose` is deleted. Every receiver writes at receive time: the websocket parser for every tracking-normal frame (the replayer reuses it), and **ZeroMQ now too**, for every `tracking_pose` (not `kf_pose`: the node pose lags the tracking stream by 50–300 ms, over a second during loop closure). `compare_demo_configs.py` wires the replayer's pose sink.
- **Key `(frame_epoch, sensor_ts_ns)` as a regression detector.** A same-epoch write whose stamp went backwards is accepted (the sender says this is the pose now: a looped replay, a bag loop, a restarted bridge, a stepped clock) and counted in `sensor_ts_regressions`, with a warning at most once a minute. Only two writes are rejected, both impossible from the single shipped writer and kept as a safety net for embedders that add one: a previous epoch (`older_epoch`) and an epoch-less write into an epoch-bearing mailbox (`epochless_into_epoch`). No time window anywhere. A stamp of zero counts as no stamp; the wall `timestamp` is the fallback key.
- **ZeroMQ session epoch.** The subscriber mints one: 0, then +1 whenever a tracking stamp jumps back by more than 5 s (the same constant as the ingest clock's re-base), so a bag loop or bridge restart is a new session for the agent's frame-reset logic. It is passed to the mailbox, set on every `FramePacket.frame_epoch`, and shown in `liveness()`.
- **ZeroMQ keyframe stamp.** A `kf_pose` without `stamp_ms` inherited this process's wall clock, which mis-paired the keyframe and would have poisoned the mailbox key. It now inherits the last tracking stamp, or the window's newest camera stamp when that image was already enqueued (no double processing of one image); the wall clock remains only as a last resort with an empty window, where it cannot pair and never reaches the mailbox. `kf_stamps_inherited` is exposed in `liveness()` as the measure of the bridge-side gap. The RTAB-Map setup guide documented a message shape the parser rejects; it now shows the real one and the stamp clock contract.
- **Payload** (`/stats`, `/search/semantic`, `/search/label`, MCP), all additive: `sensor_ts_ns`, `pose_clock` (`sender` = the header's own wall clock, `server` = this process's, `null` before any tag is known), `age_s` on the server's clock since the last accepted write, `stale` = `age_s > robot_pose.stale_after_s`, `stale_after_s`, `writes_accepted`, `sensor_ts_regressions`, `rejected_writes`, `rejected_by_reason`. Built under the working-memory lock, returned as a fresh copy. `POST /reset` clears it all.
- **Config.** New `robot_pose: {stale_after_s: 0.5}`, diagnostic only: the RC-car agent's `stale_abort_s` (2.5 s) stays the safety bound and the agent is untouched. 0.5 is 2.5 nominal periods of a 5 Hz phone stream (session1's p99 receive gap is 0.28 s, so 0.3 would flicker). Validated at startup next to the ingest keys; a bad value is a config error before any model loads.
- **Websocket sink contract.** `pose_sink(t_wc, q, unix_ts, frame_epoch, sensor_ts_ns=…, pose_clock=…)`. Embedders with a 4-positional sink need `**kw`.
- **Docs**: rest-api.md, mcp.md, configuration.md, rtabmap-setup.md.

## Design review before code

Three lenses; two refuted the first design and the implementation follows the corrected one (recorded in the plan):

- The strict rule I first wrote, reject any same-epoch older stamp, would have frozen the pose whenever a source restarts its stamps without an epoch bump. The plan's own G1-C gate does exactly that (session1 streamed in a loop behind one handshake) and would have failed by construction, as would a ZeroMQ bag loop or bridge restart. The root cause was that the rule existed to arbitrate against the pipeline's late write; deleting that write removes the need for arbitration, and the key becomes a detector.
- `kf_pose` writes were harmful: with an inherited stamp they replaced the fresher tracking pose at the same key, a periodic backwards blip the agent could read as a discontinuity.
- The ZeroMQ last-resort wall stamp must never become the mailbox key.
- Zero stamps, a torn read in the payload builder, startup validation of the threshold, the `sensor`/`sender` naming, and six more sink tests than the design listed.

## Gate

Headless `dual` replay of `recordings/session1`, packaged defaults (lossless, sensor clock), trace on (record: `eval/baselines/2026-09-sensor-clock/task4-pose-mailbox/` = script + verdict):

| check | result |
|---|---|
| multiset vs sensor anchor B1 | identical, 124/65 @53 `ad6f71a5b89c8506` |
| dequeue / receiver sequences vs B1 | identical (86 / 240) |
| per-line `depth_valid_frac` vs the task-2 record | identical (240) |
| final `robot_pose` xyz / quaternion / timestamp / frame_epoch vs the task-2 record | equal (last received frame, seq 405, epoch 0) |
| `sensor_ts_ns` == that frame's stamp, `pose_clock` | 683373591451416, `sender` |
| single writer: `writes_accepted` == tracking-normal receiver lines | 240 == 240 |
| `sensor_ts_regressions` / `rejected_writes` | 0 / 0 |

**PASS.** The mailbox never touches memory, so the anchor holds by construction; the pose predicates are the new part. `stale` is true at the end of the run by definition (the recording ended 40 s before the harness read `/stats`).

## Tests

`tests/test_pose_mailbox.py` (new, CPU-only): the single-writer rule (older stamp accepted and counted; new epoch with a smaller stamp not a regression; older epoch rejected even with a larger stamp; epoch-less write into an epoch mailbox rejected with the epoch unchanged; first epoch adopts; equal key accepted and keeps the clock tag; regressions judged on the sensor stamp, not the wall timestamp; wall timestamp as the key without stamps and zero counting as none; the looped-sender shape with one warning per minute; second-writer rejections warning at 1/100/1000), payload (age/stale/counters, copy semantics, JSON-safe with numpy inputs, threshold validated not coerced incl. a scalar `robot_pose:` block, reset), the websocket sink (stamp + `sender`/`server` tags, zero stamp → none, end to end with the source guard that the pipeline never calls `update_robot_pose`), ZeroMQ (30 tracking writes and none for `kf_pose`, the stamp-less keyframe inheriting the tracking stamp, a >5 s wrap minting epoch 1 with the packet carrying it, a zero stamp neither bumping the epoch nor becoming the reference, a 1 s step counted as a regression, the fallback chain with the camera-stamp duplicate avoidance, no sink). `tests/test_demo_entrypoint.py` (new): a bad `robot_pose` / `ingest` value exits through `parser.error` before the segmenter loads, and a bytecode pin that the validators are bound before their first use. `tests/test_pose_receive_time.py`: the two dual-writer tests replaced, six sink lambdas made kwargs-aware, class renamed to the mailbox. Agent: two contract pins (`stale: true` + advancing timestamp → arrived; `stale: false` + frozen timestamp → `stale_stop` within `stale_abort_s`), the static fixture carries the new keys, `_parse_pose` pinned to ignore them. Canonical suite: **699 passed, 1 failed** on the final tree; the failure is the known pre-existing flaky `examples/rc_car_agent/tests/test_server.py::test_baseline_no_match_resumes_search_e2e` (30 s timeout shape recorded in PR #29; the agent code is untouched by this PR and the test does not touch the pose payload).

## Reviewed

Three adversarial lenses on the uncommitted diff (mailbox rule + threads; receivers + wiring + agent; gate + docs + tests). None found a gate or invariant failure. One real defect, folded in:

- **`rtsm demo` crashed at startup since PR #33.** Task 3 moved the config validation above the model load in `demo.py` but left the `LaneConfig` import as a function-local import further down, so Python compiled the early reference as an unbound local; this task's `resolve_pose_stale_after_s` call sat one line below it with the same fault. The test suite never exercised the entry point. Both imports now bind before the validation block, and `tests/test_demo_entrypoint.py` drives the block with bad config (exit through `parser.error` before the segmenter) plus a bytecode pin. This fixes main, not only this branch.
- Hardening from the same review: a scalar `robot_pose:` block raises a config error instead of an `AttributeError` traceback; `frame_epoch` is coerced to `int` (a numpy epoch made the payload non-JSON); the regression warning prints both keys; a ZeroMQ stamp ≤ 0 neither bumps the epoch nor becomes the reference stamp (the three components now agree on what "no stamp" means); the duplicate-image avoidance for stamp-less keyframes compares the camera stamp actually paired, not the pose stamp; `kf_stamps_inherited` counts only keyframes.
- Wording: stale comments and test docstrings from the first design, the pipeline log line, the MCP reference (its example is marked abbreviated and `relational_query` never carried a pose), and the session1 gap figures (p99 0.27 s, max 0.35 s).
- The gate script's predicates were exact for session1 but encoded the wrong general rule; they now use the last tracking-normal receiver line and assert zero parse errors.

Known and stated: a stamp-less keyframe whose paired image was already admitted, with no newer frame in the window yet, re-processes that image once (the same residual the old wall-clock pairing had); the bridge-side `stamp_ms` removes it.

## Not in this PR

The analytics-owned Tier-2 rollup and `/healthz.frame_flow` sourced from the lanes (task 5), config key moves (task 6), G1-C (whose sender must present a fresh `session_id` per loop, as a real phone does; noted in the plan), and the bridge-side `stamp_ms` on `kf_pose`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
